### PR TITLE
feat: add typed hook input structs with agent_id/agent_type fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Typed hook input structs for all 10 hook event types: `PreToolUseHookInput`, `PostToolUseHookInput`, `PostToolUseFailureHookInput`, `PermissionRequestHookInput`, `UserPromptSubmitHookInput`, `StopHookInput`, `SubagentStopHookInput`, `SubagentStartHookInput`, `PreCompactHookInput`, `NotificationHookInput`.
+- `BaseHookInput` struct with common fields shared across all hook events.
+- `SubagentContext` struct with `AgentID` and `AgentType` fields for correlating tool calls to sub-agents running in parallel. Embedded in `PreToolUseHookInput`, `PostToolUseHookInput`, `PostToolUseFailureHookInput`, and `PermissionRequestHookInput`.
+- `TypedHookInput` marker interface implemented by all typed hook input structs.
+- `ParseHookInput` function to convert a raw `HookInput` map into the appropriate typed struct.
+- No breaking changes: `HookInput` (`map[string]any`) and `HookCallback` signature remain unchanged.

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -28,14 +28,23 @@ func displayMessage(msg claude.Message) {
 }
 
 // checkBashCommand blocks commands containing forbidden patterns.
+// Demonstrates ParseHookInput for type-safe access to hook fields.
 func checkBashCommand(ctx context.Context, input claude.HookInput, toolUseID string, hookCtx claude.HookContext) (claude.HookJSONOutput, error) {
-	toolName, _ := input["tool_name"].(string)
-	if toolName != "Bash" {
+	typed, err := claude.ParseHookInput(input)
+	if err != nil {
+		return claude.HookJSONOutput{}, err
+	}
+	preToolUse, ok := typed.(*claude.PreToolUseHookInput)
+	if !ok || preToolUse.ToolName != "Bash" {
 		return claude.HookJSONOutput{}, nil
 	}
 
-	toolInput, _ := input["tool_input"].(map[string]any)
-	command, _ := toolInput["command"].(string)
+	// Log sub-agent context if present (useful when multiple agents run in parallel).
+	if preToolUse.AgentID != "" {
+		fmt.Printf("  [Hook] Tool call from sub-agent %s (%s)\n", preToolUse.AgentID, preToolUse.AgentType)
+	}
+
+	command, _ := preToolUse.ToolInput["command"].(string)
 
 	blockPatterns := []string{"foo.sh", "rm -rf"}
 	for _, pattern := range blockPatterns {

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -1,0 +1,128 @@
+package claude
+
+// ParseHookInput converts a raw [HookInput] map into a typed struct.
+// Returns nil (not an error) for unrecognized hook event names, keeping
+// forward compatibility with future CLI versions that may add new events.
+func ParseHookInput(input HookInput) (TypedHookInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	eventName := stringField(input, "hook_event_name")
+	base := parseBaseHookInput(input)
+
+	switch HookEvent(eventName) {
+	case HookEventPreToolUse:
+		return &PreToolUseHookInput{
+			BaseHookInput:   base,
+			SubagentContext: parseSubagentContext(input),
+			ToolName:        stringField(input, "tool_name"),
+			ToolInput:       mapField(input, "tool_input"),
+			ToolUseID:       stringField(input, "tool_use_id"),
+		}, nil
+
+	case HookEventPostToolUse:
+		return &PostToolUseHookInput{
+			BaseHookInput:   base,
+			SubagentContext: parseSubagentContext(input),
+			ToolName:        stringField(input, "tool_name"),
+			ToolInput:       mapField(input, "tool_input"),
+			ToolResponse:    input["tool_response"],
+			ToolUseID:       stringField(input, "tool_use_id"),
+		}, nil
+
+	case HookEventPostToolUseFailure:
+		return &PostToolUseFailureHookInput{
+			BaseHookInput:   base,
+			SubagentContext: parseSubagentContext(input),
+			ToolName:        stringField(input, "tool_name"),
+			ToolInput:       mapField(input, "tool_input"),
+			ToolUseID:       stringField(input, "tool_use_id"),
+			Error:           stringField(input, "error"),
+			IsInterrupt:     boolField(input, "is_interrupt"),
+		}, nil
+
+	case HookEventPermissionRequest:
+		return &PermissionRequestHookInput{
+			BaseHookInput:   base,
+			SubagentContext: parseSubagentContext(input),
+			ToolName:        stringField(input, "tool_name"),
+			ToolInput:       mapField(input, "tool_input"),
+			PermissionSuggestions: sliceField(input, "permission_suggestions"),
+		}, nil
+
+	case HookEventUserPromptSubmit:
+		return &UserPromptSubmitHookInput{
+			BaseHookInput: base,
+			Prompt:        stringField(input, "prompt"),
+		}, nil
+
+	case HookEventStop:
+		return &StopHookInput{
+			BaseHookInput:  base,
+			StopHookActive: boolField(input, "stop_hook_active"),
+		}, nil
+
+	case HookEventSubagentStop:
+		return &SubagentStopHookInput{
+			BaseHookInput:       base,
+			StopHookActive:      boolField(input, "stop_hook_active"),
+			AgentID:             stringField(input, "agent_id"),
+			AgentTranscriptPath: stringField(input, "agent_transcript_path"),
+			AgentType:           stringField(input, "agent_type"),
+		}, nil
+
+	case HookEventSubagentStart:
+		return &SubagentStartHookInput{
+			BaseHookInput: base,
+			AgentID:       stringField(input, "agent_id"),
+			AgentType:     stringField(input, "agent_type"),
+		}, nil
+
+	case HookEventPreCompact:
+		return &PreCompactHookInput{
+			BaseHookInput:      base,
+			Trigger:            stringField(input, "trigger"),
+			CustomInstructions: stringField(input, "custom_instructions"),
+		}, nil
+
+	case HookEventNotification:
+		return &NotificationHookInput{
+			BaseHookInput:    base,
+			Message:          stringField(input, "message"),
+			Title:            stringField(input, "title"),
+			NotificationType: stringField(input, "notification_type"),
+		}, nil
+
+	default:
+		// Forward-compatible: return nil for unrecognized events.
+		return nil, nil
+	}
+}
+
+func parseBaseHookInput(m map[string]any) BaseHookInput {
+	return BaseHookInput{
+		SessionID:      stringField(m, "session_id"),
+		TranscriptPath: stringField(m, "transcript_path"),
+		Cwd:            stringField(m, "cwd"),
+		PermissionMode: stringField(m, "permission_mode"),
+		HookEventName:  stringField(m, "hook_event_name"),
+	}
+}
+
+func parseSubagentContext(m map[string]any) SubagentContext {
+	return SubagentContext{
+		AgentID:   stringField(m, "agent_id"),
+		AgentType: stringField(m, "agent_type"),
+	}
+}
+
+func mapField(m map[string]any, key string) map[string]any {
+	v, _ := m[key].(map[string]any)
+	return v
+}
+
+func sliceField(m map[string]any, key string) []any {
+	v, _ := m[key].([]any)
+	return v
+}

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -1,0 +1,692 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// Compile-time interface satisfaction checks.
+var (
+	_ TypedHookInput = (*PreToolUseHookInput)(nil)
+	_ TypedHookInput = (*PostToolUseHookInput)(nil)
+	_ TypedHookInput = (*PostToolUseFailureHookInput)(nil)
+	_ TypedHookInput = (*PermissionRequestHookInput)(nil)
+	_ TypedHookInput = (*UserPromptSubmitHookInput)(nil)
+	_ TypedHookInput = (*StopHookInput)(nil)
+	_ TypedHookInput = (*SubagentStopHookInput)(nil)
+	_ TypedHookInput = (*SubagentStartHookInput)(nil)
+	_ TypedHookInput = (*PreCompactHookInput)(nil)
+	_ TypedHookInput = (*NotificationHookInput)(nil)
+)
+
+// base returns a HookInput with common fields pre-filled.
+func base(event string) HookInput {
+	return HookInput{
+		"session_id":      "sess-1",
+		"transcript_path": "/tmp/transcript.jsonl",
+		"cwd":             "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": event,
+	}
+}
+
+func merge(a, b HookInput) HookInput {
+	out := make(HookInput, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+
+func assertBase(t *testing.T, b BaseHookInput, event string) {
+	t.Helper()
+	if b.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want %q", b.SessionID, "sess-1")
+	}
+	if b.TranscriptPath != "/tmp/transcript.jsonl" {
+		t.Errorf("TranscriptPath = %q, want %q", b.TranscriptPath, "/tmp/transcript.jsonl")
+	}
+	if b.Cwd != "/home/user" {
+		t.Errorf("Cwd = %q, want %q", b.Cwd, "/home/user")
+	}
+	if b.HookEventName != event {
+		t.Errorf("HookEventName = %q, want %q", b.HookEventName, event)
+	}
+}
+
+func TestParseHookInput_Nil(t *testing.T) {
+	result, err := ParseHookInput(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil, got %T", result)
+	}
+}
+
+func TestParseHookInput_UnknownEvent(t *testing.T) {
+	result, err := ParseHookInput(base("FutureEvent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil for unknown event, got %T", result)
+	}
+}
+
+func TestParseHookInput_PreToolUse(t *testing.T) {
+	input := merge(base("PreToolUse"), HookInput{
+		"tool_name":   "Bash",
+		"tool_input":  map[string]any{"command": "echo hello"},
+		"tool_use_id": "toolu_abc123",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed, ok := result.(*PreToolUseHookInput)
+	if !ok {
+		t.Fatalf("expected *PreToolUseHookInput, got %T", result)
+	}
+	assertBase(t, typed.BaseHookInput, "PreToolUse")
+	if typed.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want %q", typed.ToolName, "Bash")
+	}
+	if typed.ToolUseID != "toolu_abc123" {
+		t.Errorf("ToolUseID = %q, want %q", typed.ToolUseID, "toolu_abc123")
+	}
+	if typed.AgentID != "" {
+		t.Errorf("AgentID should be empty on main thread, got %q", typed.AgentID)
+	}
+}
+
+func TestParseHookInput_PreToolUse_WithAgentID(t *testing.T) {
+	input := merge(base("PreToolUse"), HookInput{
+		"tool_name":   "Bash",
+		"tool_input":  map[string]any{"command": "echo hello"},
+		"tool_use_id": "toolu_abc123",
+		"agent_id":    "agent-42",
+		"agent_type":  "researcher",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PreToolUseHookInput)
+	if typed.AgentID != "agent-42" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-42")
+	}
+	if typed.AgentType != "researcher" {
+		t.Errorf("AgentType = %q, want %q", typed.AgentType, "researcher")
+	}
+}
+
+func TestParseHookInput_PostToolUse(t *testing.T) {
+	input := merge(base("PostToolUse"), HookInput{
+		"tool_name":     "Bash",
+		"tool_input":    map[string]any{"command": "ls"},
+		"tool_response": map[string]any{"content": []any{map[string]any{"type": "text", "text": "file.txt"}}},
+		"tool_use_id":   "toolu_def456",
+		"agent_id":      "agent-7",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PostToolUseHookInput)
+	assertBase(t, typed.BaseHookInput, "PostToolUse")
+	if typed.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want %q", typed.ToolName, "Bash")
+	}
+	if typed.ToolResponse == nil {
+		t.Error("ToolResponse should not be nil")
+	}
+	if typed.AgentID != "agent-7" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-7")
+	}
+}
+
+func TestParseHookInput_PostToolUseFailure(t *testing.T) {
+	input := merge(base("PostToolUseFailure"), HookInput{
+		"tool_name":    "Write",
+		"tool_input":   map[string]any{"path": "/etc/passwd"},
+		"tool_use_id":  "toolu_fail1",
+		"error":        "permission denied",
+		"is_interrupt":  true,
+		"agent_id":     "agent-99",
+		"agent_type":   "code-reviewer",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PostToolUseFailureHookInput)
+	assertBase(t, typed.BaseHookInput, "PostToolUseFailure")
+	if typed.Error != "permission denied" {
+		t.Errorf("Error = %q, want %q", typed.Error, "permission denied")
+	}
+	if !typed.IsInterrupt {
+		t.Error("IsInterrupt should be true")
+	}
+	if typed.AgentID != "agent-99" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-99")
+	}
+}
+
+func TestParseHookInput_PermissionRequest(t *testing.T) {
+	input := merge(base("PermissionRequest"), HookInput{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": "rm -rf /"},
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PermissionRequestHookInput)
+	assertBase(t, typed.BaseHookInput, "PermissionRequest")
+	if typed.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want %q", typed.ToolName, "Bash")
+	}
+}
+
+func TestParseHookInput_UserPromptSubmit(t *testing.T) {
+	input := merge(base("UserPromptSubmit"), HookInput{
+		"prompt": "explain this code",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*UserPromptSubmitHookInput)
+	assertBase(t, typed.BaseHookInput, "UserPromptSubmit")
+	if typed.Prompt != "explain this code" {
+		t.Errorf("Prompt = %q, want %q", typed.Prompt, "explain this code")
+	}
+}
+
+func TestParseHookInput_Stop(t *testing.T) {
+	input := merge(base("Stop"), HookInput{
+		"stop_hook_active": true,
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*StopHookInput)
+	assertBase(t, typed.BaseHookInput, "Stop")
+	if !typed.StopHookActive {
+		t.Error("StopHookActive should be true")
+	}
+}
+
+func TestParseHookInput_SubagentStop(t *testing.T) {
+	input := merge(base("SubagentStop"), HookInput{
+		"stop_hook_active":       false,
+		"agent_id":               "agent-42",
+		"agent_transcript_path":  "/tmp/agent-42.jsonl",
+		"agent_type":             "general-purpose",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*SubagentStopHookInput)
+	assertBase(t, typed.BaseHookInput, "SubagentStop")
+	if typed.AgentID != "agent-42" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-42")
+	}
+	if typed.AgentTranscriptPath != "/tmp/agent-42.jsonl" {
+		t.Errorf("AgentTranscriptPath = %q, want %q", typed.AgentTranscriptPath, "/tmp/agent-42.jsonl")
+	}
+	if typed.AgentType != "general-purpose" {
+		t.Errorf("AgentType = %q, want %q", typed.AgentType, "general-purpose")
+	}
+}
+
+func TestParseHookInput_SubagentStart(t *testing.T) {
+	input := merge(base("SubagentStart"), HookInput{
+		"agent_id":   "agent-42",
+		"agent_type": "researcher",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*SubagentStartHookInput)
+	assertBase(t, typed.BaseHookInput, "SubagentStart")
+	if typed.AgentID != "agent-42" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-42")
+	}
+	if typed.AgentType != "researcher" {
+		t.Errorf("AgentType = %q, want %q", typed.AgentType, "researcher")
+	}
+}
+
+func TestParseHookInput_PreCompact(t *testing.T) {
+	input := merge(base("PreCompact"), HookInput{
+		"trigger":              "auto",
+		"custom_instructions":  "keep it short",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PreCompactHookInput)
+	assertBase(t, typed.BaseHookInput, "PreCompact")
+	if typed.Trigger != "auto" {
+		t.Errorf("Trigger = %q, want %q", typed.Trigger, "auto")
+	}
+	if typed.CustomInstructions != "keep it short" {
+		t.Errorf("CustomInstructions = %q, want %q", typed.CustomInstructions, "keep it short")
+	}
+}
+
+func TestParseHookInput_Notification(t *testing.T) {
+	input := merge(base("Notification"), HookInput{
+		"message":           "task complete",
+		"title":             "Done",
+		"notification_type": "info",
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*NotificationHookInput)
+	assertBase(t, typed.BaseHookInput, "Notification")
+	if typed.Message != "task complete" {
+		t.Errorf("Message = %q, want %q", typed.Message, "task complete")
+	}
+	if typed.Title != "Done" {
+		t.Errorf("Title = %q, want %q", typed.Title, "Done")
+	}
+	if typed.NotificationType != "info" {
+		t.Errorf("NotificationType = %q, want %q", typed.NotificationType, "info")
+	}
+}
+
+// --- Backward compatibility tests ---
+// These tests replicate the exact map[string]any access patterns that existing
+// consumers use (as seen in examples/hooks/main.go before our changes).
+// They verify that HookInput remains a plain map[string]any and that the
+// original untyped access pattern still works identically.
+
+func TestHookInput_BackwardCompat_PreToolUseMapAccess(t *testing.T) {
+	// This is the exact pattern from the original checkBashCommand example.
+	input := HookInput{
+		"session_id":      "sess-1",
+		"transcript_path": "/tmp/transcript.jsonl",
+		"cwd":             "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]any{"command": "echo hello"},
+		"tool_use_id":     "toolu_abc123",
+	}
+
+	// Original access pattern: direct type assertions on the map.
+	toolName, _ := input["tool_name"].(string)
+	if toolName != "Bash" {
+		t.Errorf("toolName = %q, want %q", toolName, "Bash")
+	}
+
+	toolInput, _ := input["tool_input"].(map[string]any)
+	command, _ := toolInput["command"].(string)
+	if command != "echo hello" {
+		t.Errorf("command = %q, want %q", command, "echo hello")
+	}
+}
+
+func TestHookInput_BackwardCompat_PostToolUseMapAccess(t *testing.T) {
+	// This is the exact pattern from the original reviewToolOutput example.
+	input := HookInput{
+		"session_id":      "sess-1",
+		"transcript_path": "/tmp/transcript.jsonl",
+		"cwd":             "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Bash",
+		"tool_response":   "error: file not found",
+	}
+
+	// Original access pattern: fmt.Sprintf on tool_response.
+	toolResponse := fmt.Sprintf("%v", input["tool_response"])
+	if toolResponse != "error: file not found" {
+		t.Errorf("toolResponse = %q, want %q", toolResponse, "error: file not found")
+	}
+}
+
+func TestHookInput_BackwardCompat_CallbackSignature(t *testing.T) {
+	// Verify that a HookCallback written with the old map-based style
+	// still compiles and works correctly.
+	var callback HookCallback = func(ctx context.Context, input HookInput, toolUseID string, hookCtx HookContext) (HookJSONOutput, error) {
+		// Old-style: direct map access, no ParseHookInput.
+		name, _ := input["tool_name"].(string)
+		return HookJSONOutput{"saw_tool": name}, nil
+	}
+
+	input := HookInput{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Bash",
+	}
+	output, err := callback(context.Background(), input, "toolu_1", HookContext{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output["saw_tool"] != "Bash" {
+		t.Errorf("output[saw_tool] = %v, want %q", output["saw_tool"], "Bash")
+	}
+}
+
+func TestHookInput_BackwardCompat_HookMatcherConfig(t *testing.T) {
+	// Verify the hooks configuration pattern still works.
+	hooks := map[HookEvent][]HookMatcher{
+		HookEventPreToolUse: {
+			{
+				Matcher: "Bash",
+				Hooks: []HookCallback{
+					func(ctx context.Context, input HookInput, toolUseID string, hookCtx HookContext) (HookJSONOutput, error) {
+						return HookJSONOutput{}, nil
+					},
+				},
+			},
+		},
+		HookEventPostToolUse: {
+			{
+				Matcher: "Bash",
+				Hooks: []HookCallback{
+					func(ctx context.Context, input HookInput, toolUseID string, hookCtx HookContext) (HookJSONOutput, error) {
+						return HookJSONOutput{
+							"systemMessage": "done",
+						}, nil
+					},
+				},
+			},
+		},
+	}
+
+	if len(hooks) != 2 {
+		t.Errorf("expected 2 hook events, got %d", len(hooks))
+	}
+	if len(hooks[HookEventPreToolUse]) != 1 {
+		t.Errorf("expected 1 PreToolUse matcher, got %d", len(hooks[HookEventPreToolUse]))
+	}
+	if hooks[HookEventPreToolUse][0].Matcher != "Bash" {
+		t.Errorf("matcher = %q, want %q", hooks[HookEventPreToolUse][0].Matcher, "Bash")
+	}
+}
+
+// --- Edge case tests ---
+
+func TestParseHookInput_EmptyMap(t *testing.T) {
+	// Empty map has no hook_event_name, should return nil (unknown event).
+	result, err := ParseHookInput(HookInput{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil for empty map, got %T", result)
+	}
+}
+
+func TestParseHookInput_MissingOptionalFields(t *testing.T) {
+	// Minimal PreToolUse — only hook_event_name, no tool_name etc.
+	// Should parse without error; missing fields get zero values.
+	input := HookInput{"hook_event_name": "PreToolUse"}
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PreToolUseHookInput)
+	if typed.ToolName != "" {
+		t.Errorf("ToolName should be zero value, got %q", typed.ToolName)
+	}
+	if typed.ToolInput != nil {
+		t.Errorf("ToolInput should be nil, got %v", typed.ToolInput)
+	}
+	if typed.AgentID != "" {
+		t.Errorf("AgentID should be zero value, got %q", typed.AgentID)
+	}
+}
+
+func TestParseHookInput_ExtraUnknownFields(t *testing.T) {
+	// CLI sends a field we don't know about — ParseHookInput should not fail.
+	input := merge(base("PreToolUse"), HookInput{
+		"tool_name":      "Bash",
+		"tool_input":     map[string]any{"command": "echo hi"},
+		"tool_use_id":    "toolu_xyz",
+		"future_field":   "some_value",
+		"another_field":  42,
+	})
+
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed := result.(*PreToolUseHookInput)
+	if typed.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want %q", typed.ToolName, "Bash")
+	}
+}
+
+// --- JSON round-trip tests ---
+// Verify that the json struct tags produce correct JSON field names
+// and that encoding/json can unmarshal real CLI-shaped JSON into our types.
+
+func TestPreToolUseHookInput_JSONRoundTrip(t *testing.T) {
+	// Simulate raw JSON from the CLI.
+	raw := `{
+		"session_id": "sess-abc",
+		"transcript_path": "/tmp/t.jsonl",
+		"cwd": "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {"command": "echo hi"},
+		"tool_use_id": "toolu_123",
+		"agent_id": "agent-5",
+		"agent_type": "researcher"
+	}`
+
+	var typed PreToolUseHookInput
+	if err := json.Unmarshal([]byte(raw), &typed); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if typed.SessionID != "sess-abc" {
+		t.Errorf("SessionID = %q, want %q", typed.SessionID, "sess-abc")
+	}
+	if typed.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want %q", typed.ToolName, "Bash")
+	}
+	if typed.AgentID != "agent-5" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-5")
+	}
+	if typed.AgentType != "researcher" {
+		t.Errorf("AgentType = %q, want %q", typed.AgentType, "researcher")
+	}
+	cmd, _ := typed.ToolInput["command"].(string)
+	if cmd != "echo hi" {
+		t.Errorf("ToolInput[command] = %q, want %q", cmd, "echo hi")
+	}
+
+	// Marshal back and verify field names are snake_case.
+	out, err := json.Marshal(&typed)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var m map[string]any
+	json.Unmarshal(out, &m)
+	for _, key := range []string{"session_id", "tool_name", "tool_use_id", "agent_id", "agent_type", "hook_event_name"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("marshaled JSON missing expected key %q", key)
+		}
+	}
+}
+
+func TestPreToolUseHookInput_JSONRoundTrip_NoAgent(t *testing.T) {
+	// Main-thread tool call: no agent_id/agent_type in JSON.
+	raw := `{
+		"session_id": "sess-abc",
+		"transcript_path": "/tmp/t.jsonl",
+		"cwd": "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {"command": "ls"},
+		"tool_use_id": "toolu_456"
+	}`
+
+	var typed PreToolUseHookInput
+	if err := json.Unmarshal([]byte(raw), &typed); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if typed.AgentID != "" {
+		t.Errorf("AgentID should be empty, got %q", typed.AgentID)
+	}
+	if typed.AgentType != "" {
+		t.Errorf("AgentType should be empty, got %q", typed.AgentType)
+	}
+
+	// Marshal back: omitempty should omit agent_id and agent_type.
+	out, err := json.Marshal(&typed)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var m map[string]any
+	json.Unmarshal(out, &m)
+	if _, ok := m["agent_id"]; ok {
+		t.Error("agent_id should be omitted when empty")
+	}
+	if _, ok := m["agent_type"]; ok {
+		t.Error("agent_type should be omitted when empty")
+	}
+}
+
+func TestSubagentStopHookInput_JSONRoundTrip(t *testing.T) {
+	raw := `{
+		"session_id": "sess-1",
+		"transcript_path": "/tmp/t.jsonl",
+		"cwd": "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "SubagentStop",
+		"stop_hook_active": true,
+		"agent_id": "agent-42",
+		"agent_transcript_path": "/tmp/agent-42.jsonl",
+		"agent_type": "general-purpose"
+	}`
+
+	var typed SubagentStopHookInput
+	if err := json.Unmarshal([]byte(raw), &typed); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if typed.AgentID != "agent-42" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-42")
+	}
+	if !typed.StopHookActive {
+		t.Error("StopHookActive should be true")
+	}
+	if typed.AgentTranscriptPath != "/tmp/agent-42.jsonl" {
+		t.Errorf("AgentTranscriptPath = %q, want %q", typed.AgentTranscriptPath, "/tmp/agent-42.jsonl")
+	}
+}
+
+func TestPostToolUseFailureHookInput_JSONRoundTrip(t *testing.T) {
+	raw := `{
+		"session_id": "sess-1",
+		"transcript_path": "/tmp/t.jsonl",
+		"cwd": "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "PostToolUseFailure",
+		"tool_name": "Write",
+		"tool_input": {"path": "/etc/passwd"},
+		"tool_use_id": "toolu_fail",
+		"error": "permission denied",
+		"is_interrupt": true,
+		"agent_id": "agent-99",
+		"agent_type": "code-reviewer"
+	}`
+
+	var typed PostToolUseFailureHookInput
+	if err := json.Unmarshal([]byte(raw), &typed); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if typed.Error != "permission denied" {
+		t.Errorf("Error = %q, want %q", typed.Error, "permission denied")
+	}
+	if !typed.IsInterrupt {
+		t.Error("IsInterrupt should be true")
+	}
+	if typed.AgentID != "agent-99" {
+		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-99")
+	}
+}
+
+// --- ParseHookInput consistency with JSON unmarshal ---
+// Verify that ParseHookInput (from map) and json.Unmarshal (from bytes)
+// produce equivalent results for the same data.
+
+func TestParseHookInput_ConsistentWithJSON(t *testing.T) {
+	// Start from JSON bytes (what the CLI actually sends over the wire).
+	raw := `{
+		"session_id": "sess-1",
+		"transcript_path": "/tmp/t.jsonl",
+		"cwd": "/home/user",
+		"permission_mode": "default",
+		"hook_event_name": "PreToolUse",
+		"tool_name": "Bash",
+		"tool_input": {"command": "echo hello"},
+		"tool_use_id": "toolu_abc",
+		"agent_id": "agent-42",
+		"agent_type": "researcher"
+	}`
+
+	// Path 1: json.Unmarshal into map, then ParseHookInput (this is what the SDK does).
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("unmarshal to map error: %v", err)
+	}
+	fromMap, err := ParseHookInput(HookInput(m))
+	if err != nil {
+		t.Fatalf("ParseHookInput error: %v", err)
+	}
+	parsed := fromMap.(*PreToolUseHookInput)
+
+	// Path 2: json.Unmarshal directly into typed struct.
+	var direct PreToolUseHookInput
+	if err := json.Unmarshal([]byte(raw), &direct); err != nil {
+		t.Fatalf("unmarshal to struct error: %v", err)
+	}
+
+	// Both paths should produce the same result.
+	if parsed.SessionID != direct.SessionID {
+		t.Errorf("SessionID mismatch: %q vs %q", parsed.SessionID, direct.SessionID)
+	}
+	if parsed.ToolName != direct.ToolName {
+		t.Errorf("ToolName mismatch: %q vs %q", parsed.ToolName, direct.ToolName)
+	}
+	if parsed.ToolUseID != direct.ToolUseID {
+		t.Errorf("ToolUseID mismatch: %q vs %q", parsed.ToolUseID, direct.ToolUseID)
+	}
+	if parsed.AgentID != direct.AgentID {
+		t.Errorf("AgentID mismatch: %q vs %q", parsed.AgentID, direct.AgentID)
+	}
+	if parsed.AgentType != direct.AgentType {
+		t.Errorf("AgentType mismatch: %q vs %q", parsed.AgentType, direct.AgentType)
+	}
+}

--- a/hooks.go
+++ b/hooks.go
@@ -21,7 +21,134 @@ const (
 // HookInput represents the input data for a hook callback.
 // The map contains fields specific to each hook event type.
 // Common fields: session_id, transcript_path, cwd, permission_mode, hook_event_name.
+//
+// Use [ParseHookInput] to convert a HookInput into a typed struct.
 type HookInput map[string]any
+
+// TypedHookInput is a marker interface implemented by all typed hook input structs.
+// Use [ParseHookInput] to obtain a TypedHookInput from a raw [HookInput] map.
+type TypedHookInput interface {
+	hookInputMarker()
+}
+
+// BaseHookInput contains fields common to all hook events.
+type BaseHookInput struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	Cwd            string `json:"cwd"`
+	PermissionMode string `json:"permission_mode"`
+	HookEventName  string `json:"hook_event_name"`
+}
+
+// SubagentContext carries optional sub-agent attribution fields.
+// Present only when a hook fires from inside a Task-spawned sub-agent.
+// The AgentID matches the value emitted by that sub-agent's SubagentStart/SubagentStop hooks.
+type SubagentContext struct {
+	AgentID   string `json:"agent_id,omitempty"`
+	AgentType string `json:"agent_type,omitempty"`
+}
+
+// PreToolUseHookInput is the typed input for PreToolUse hook events.
+type PreToolUseHookInput struct {
+	BaseHookInput
+	SubagentContext
+	ToolName  string         `json:"tool_name"`
+	ToolInput map[string]any `json:"tool_input"`
+	ToolUseID string         `json:"tool_use_id"`
+}
+
+func (*PreToolUseHookInput) hookInputMarker() {}
+
+// PostToolUseHookInput is the typed input for PostToolUse hook events.
+type PostToolUseHookInput struct {
+	BaseHookInput
+	SubagentContext
+	ToolName     string         `json:"tool_name"`
+	ToolInput    map[string]any `json:"tool_input"`
+	ToolResponse any            `json:"tool_response"`
+	ToolUseID    string         `json:"tool_use_id"`
+}
+
+func (*PostToolUseHookInput) hookInputMarker() {}
+
+// PostToolUseFailureHookInput is the typed input for PostToolUseFailure hook events.
+type PostToolUseFailureHookInput struct {
+	BaseHookInput
+	SubagentContext
+	ToolName    string         `json:"tool_name"`
+	ToolInput   map[string]any `json:"tool_input"`
+	ToolUseID   string         `json:"tool_use_id"`
+	Error       string         `json:"error"`
+	IsInterrupt bool           `json:"is_interrupt,omitempty"`
+}
+
+func (*PostToolUseFailureHookInput) hookInputMarker() {}
+
+// PermissionRequestHookInput is the typed input for PermissionRequest hook events.
+type PermissionRequestHookInput struct {
+	BaseHookInput
+	SubagentContext
+	ToolName              string         `json:"tool_name"`
+	ToolInput             map[string]any `json:"tool_input"`
+	PermissionSuggestions []any          `json:"permission_suggestions,omitempty"`
+}
+
+func (*PermissionRequestHookInput) hookInputMarker() {}
+
+// UserPromptSubmitHookInput is the typed input for UserPromptSubmit hook events.
+type UserPromptSubmitHookInput struct {
+	BaseHookInput
+	Prompt string `json:"prompt"`
+}
+
+func (*UserPromptSubmitHookInput) hookInputMarker() {}
+
+// StopHookInput is the typed input for Stop hook events.
+type StopHookInput struct {
+	BaseHookInput
+	StopHookActive bool `json:"stop_hook_active"`
+}
+
+func (*StopHookInput) hookInputMarker() {}
+
+// SubagentStopHookInput is the typed input for SubagentStop hook events.
+type SubagentStopHookInput struct {
+	BaseHookInput
+	StopHookActive       bool   `json:"stop_hook_active"`
+	AgentID              string `json:"agent_id"`
+	AgentTranscriptPath  string `json:"agent_transcript_path"`
+	AgentType            string `json:"agent_type"`
+}
+
+func (*SubagentStopHookInput) hookInputMarker() {}
+
+// SubagentStartHookInput is the typed input for SubagentStart hook events.
+type SubagentStartHookInput struct {
+	BaseHookInput
+	AgentID   string `json:"agent_id"`
+	AgentType string `json:"agent_type"`
+}
+
+func (*SubagentStartHookInput) hookInputMarker() {}
+
+// PreCompactHookInput is the typed input for PreCompact hook events.
+type PreCompactHookInput struct {
+	BaseHookInput
+	Trigger            string `json:"trigger"`
+	CustomInstructions string `json:"custom_instructions,omitempty"`
+}
+
+func (*PreCompactHookInput) hookInputMarker() {}
+
+// NotificationHookInput is the typed input for Notification hook events.
+type NotificationHookInput struct {
+	BaseHookInput
+	Message          string `json:"message"`
+	Title            string `json:"title,omitempty"`
+	NotificationType string `json:"notification_type"`
+}
+
+func (*NotificationHookInput) hookInputMarker() {}
 
 // HookContext provides context for hook callbacks.
 type HookContext struct {


### PR DESCRIPTION
## Summary

- Add typed structs for all 10 hook event types (`PreToolUseHookInput`, `PostToolUseHookInput`, `PostToolUseFailureHookInput`, `PermissionRequestHookInput`, `UserPromptSubmitHookInput`, `StopHookInput`, `SubagentStopHookInput`, `SubagentStartHookInput`, `PreCompactHookInput`, `NotificationHookInput`)
- Add `ParseHookInput` function to convert raw `HookInput` map into typed structs
- Add `SubagentContext` with `AgentID`/`AgentType` fields to the 4 tool-lifecycle hook inputs for correlating tool calls to sub-agents running in parallel
- No breaking changes: `HookInput` (`map[string]any`) and `HookCallback` signature remain unchanged

Closes #1

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 25 new tests pass (parsing all 10 types, JSON round-trip, backward compatibility with map-based access, edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)