### PR TITLE
fix: prevent stdin closure before MCP server initialization in Query()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Prevent stdin closure before MCP server initialization in one-shot `Query()`. When SDK MCP servers or hooks were configured, `Query()` closed stdin immediately after writing the user message, which could cause the CLI to fail during the MCP initialization handshake. The fix extracts the existing wait-for-first-result logic from `streamInput()` into a shared `waitForResultAndEndInput()` method, now used by both the interactive and one-shot code paths. ([#2](https://github.com/Flohs/claude-agent-sdk-go/issues/2))
+
 ### Added
 
 - Typed hook input structs for all 10 hook event types: `PreToolUseHookInput`, `PostToolUseHookInput`, `PostToolUseFailureHookInput`, `PermissionRequestHookInput`, `UserPromptSubmitHookInput`, `StopHookInput`, `SubagentStopHookInput`, `SubagentStartHookInput`, `PreCompactHookInput`, `NotificationHookInput`.

--- a/claude.go
+++ b/claude.go
@@ -121,7 +121,7 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 			q.close()
 			return
 		}
-		transport.EndInput()
+		q.waitForResultAndEndInput()
 
 		// Receive and parse messages
 		for msg := range q.receiveMessages() {

--- a/query.go
+++ b/query.go
@@ -549,7 +549,13 @@ func (q *query) streamInput(inputCh <-chan map[string]any) {
 		_ = q.transport.Write(string(data) + "\n")
 	}
 
-	// If we have SDK MCP servers or hooks, wait for first result before closing
+	q.waitForResultAndEndInput()
+}
+
+// waitForResultAndEndInput waits for the first result before closing stdin
+// when SDK MCP servers or hooks are configured. This prevents closing stdin
+// before the CLI completes the MCP initialization handshake.
+func (q *query) waitForResultAndEndInput() {
 	hasHooks := len(q.hooks) > 0
 	hasMcpServers := len(q.mcpRouter.servers) > 0
 

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,237 @@
+package claude
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockTransport is a test Transport that records calls and allows control over behavior.
+type mockTransport struct {
+	mu             sync.Mutex
+	written        []string
+	endInputCalled bool
+	endInputTime   time.Time
+	messages       chan map[string]any
+	closed         bool
+}
+
+func newMockTransport() *mockTransport {
+	return &mockTransport{
+		messages: make(chan map[string]any, 100),
+	}
+}
+
+func (m *mockTransport) Connect(ctx context.Context) error { return nil }
+
+func (m *mockTransport) Write(data string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.written = append(m.written, data)
+	return nil
+}
+
+func (m *mockTransport) ReadMessages(ctx context.Context) <-chan map[string]any {
+	return m.messages
+}
+
+func (m *mockTransport) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	close(m.messages)
+	return nil
+}
+
+func (m *mockTransport) IsReady() bool { return true }
+
+func (m *mockTransport) EndInput() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.endInputCalled = true
+	m.endInputTime = time.Now()
+	return nil
+}
+
+func (m *mockTransport) getEndInputCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.endInputCalled
+}
+
+func TestWaitForResultAndEndInput_NoMcpOrHooks(t *testing.T) {
+	// Without MCP servers or hooks, EndInput should be called immediately.
+	mt := newMockTransport()
+	q := newQuery(queryConfig{transport: mt})
+
+	q.waitForResultAndEndInput()
+
+	if !mt.getEndInputCalled() {
+		t.Fatal("expected EndInput to be called")
+	}
+}
+
+func TestWaitForResultAndEndInput_WithMcpServers_WaitsForResult(t *testing.T) {
+	// With MCP servers configured, EndInput should wait for firstResultCh.
+	mt := newMockTransport()
+	q := newQuery(queryConfig{
+		transport: mt,
+		mcpServers: map[string]*McpSdkServerConfig{
+			"test-server": {
+				Name: "test",
+			},
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		q.waitForResultAndEndInput()
+		close(done)
+	}()
+
+	// EndInput should NOT have been called yet
+	time.Sleep(50 * time.Millisecond)
+	if mt.getEndInputCalled() {
+		t.Fatal("EndInput should not be called before first result")
+	}
+
+	// Signal first result
+	q.firstResultOnce.Do(func() { close(q.firstResultCh) })
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForResultAndEndInput did not return after first result")
+	}
+
+	if !mt.getEndInputCalled() {
+		t.Fatal("expected EndInput to be called after first result")
+	}
+}
+
+func TestWaitForResultAndEndInput_WithHooks_WaitsForResult(t *testing.T) {
+	// With hooks configured, EndInput should wait for firstResultCh.
+	mt := newMockTransport()
+	q := newQuery(queryConfig{
+		transport: mt,
+		hooks: map[HookEvent][]HookMatcher{
+			HookEventPreToolUse: {
+				{
+					Matcher: "Bash",
+					Hooks: []HookCallback{
+						func(ctx context.Context, input HookInput, toolUseID string, hctx HookContext) (HookJSONOutput, error) {
+							return nil, nil
+						},
+					},
+				},
+			},
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		q.waitForResultAndEndInput()
+		close(done)
+	}()
+
+	// EndInput should NOT have been called yet
+	time.Sleep(50 * time.Millisecond)
+	if mt.getEndInputCalled() {
+		t.Fatal("EndInput should not be called before first result when hooks are configured")
+	}
+
+	// Signal first result
+	q.firstResultOnce.Do(func() { close(q.firstResultCh) })
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForResultAndEndInput did not return after first result")
+	}
+
+	if !mt.getEndInputCalled() {
+		t.Fatal("expected EndInput to be called after first result")
+	}
+}
+
+func TestWaitForResultAndEndInput_ContextCancellation(t *testing.T) {
+	// When context is cancelled, EndInput should still be called.
+	mt := newMockTransport()
+	q := newQuery(queryConfig{
+		transport: mt,
+		mcpServers: map[string]*McpSdkServerConfig{
+			"test-server": {
+				Name: "test",
+			},
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		q.waitForResultAndEndInput()
+		close(done)
+	}()
+
+	// Cancel the query context
+	q.cancelFn()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForResultAndEndInput did not return after context cancellation")
+	}
+
+	if !mt.getEndInputCalled() {
+		t.Fatal("expected EndInput to be called after context cancellation")
+	}
+}
+
+func TestStreamInput_UsesWaitForResultAndEndInput(t *testing.T) {
+	// Verify streamInput still works correctly with the refactored method.
+	mt := newMockTransport()
+	q := newQuery(queryConfig{
+		transport: mt,
+		mcpServers: map[string]*McpSdkServerConfig{
+			"test-server": {
+				Name: "test",
+			},
+		},
+	})
+
+	inputCh := make(chan map[string]any, 1)
+	inputCh <- map[string]any{"type": "user", "message": "hello"}
+	close(inputCh)
+
+	done := make(chan struct{})
+	go func() {
+		q.streamInput(inputCh)
+		close(done)
+	}()
+
+	// Should be waiting for first result
+	time.Sleep(50 * time.Millisecond)
+	if mt.getEndInputCalled() {
+		t.Fatal("streamInput should wait for first result before calling EndInput")
+	}
+
+	// Signal first result
+	q.firstResultOnce.Do(func() { close(q.firstResultCh) })
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("streamInput did not complete after first result")
+	}
+
+	if !mt.getEndInputCalled() {
+		t.Fatal("expected EndInput to be called")
+	}
+
+	// Verify the message was written
+	mt.mu.Lock()
+	defer mt.mu.Unlock()
+	if len(mt.written) == 0 {
+		t.Fatal("expected at least one message to be written")
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts the wait-for-first-result logic from `streamInput()` into a shared `waitForResultAndEndInput()` method on `query`
- Updates the one-shot `Query()` code path to use `waitForResultAndEndInput()` instead of calling `transport.EndInput()` immediately, preventing stdin closure before MCP servers complete initialization
- Adds tests covering the fix: MCP servers, hooks, context cancellation, and no-MCP/hooks baseline

## Test plan

- [x] `TestWaitForResultAndEndInput_NoMcpOrHooks` — EndInput called immediately without MCP/hooks (no regression)
- [x] `TestWaitForResultAndEndInput_WithMcpServers_WaitsForResult` — EndInput deferred until first result with MCP servers
- [x] `TestWaitForResultAndEndInput_WithHooks_WaitsForResult` — EndInput deferred until first result with hooks
- [x] `TestWaitForResultAndEndInput_ContextCancellation` — graceful handling on context cancel
- [x] `TestStreamInput_UsesWaitForResultAndEndInput` — interactive path unchanged after refactor
- [x] All existing tests pass
- [x] Race detector clean

Fixes #2