### PR TITLE
fix: resolve errcheck lint errors for golangci-lint v2

### DIFF
--- a/claude.go
+++ b/claude.go
@@ -63,7 +63,7 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 			opts = &Options{}
 		}
 
-		os.Setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-go")
+		_ = os.Setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-go")
 
 		// Configure permission settings
 		configuredOpts := *opts
@@ -104,7 +104,7 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 		// Initialize
 		if _, err := q.initialize(); err != nil {
 			errs <- err
-			q.close()
+			_ = q.close()
 			return
 		}
 
@@ -118,7 +118,7 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 		data, _ := json.Marshal(userMessage)
 		if err := transport.Write(string(data) + "\n"); err != nil {
 			errs <- err
-			q.close()
+			_ = q.close()
 			return
 		}
 		q.waitForResultAndEndInput()
@@ -133,13 +133,13 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 				select {
 				case messages <- parsed:
 				case <-ctx.Done():
-					q.close()
+					_ = q.close()
 					return
 				}
 			}
 		}
 
-		q.close()
+		_ = q.close()
 	}()
 
 	return messages, errs

--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ func NewClient(opts *Options) *Client {
 // Connect establishes the connection to Claude Code.
 // An optional initial prompt can be provided.
 func (c *Client) Connect(ctx context.Context, prompt ...string) error {
-	os.Setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-go-client")
+	_ = os.Setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-go-client")
 
 	// Configure permission settings
 	configuredOpts := *c.options
@@ -67,7 +67,7 @@ func (c *Client) Connect(ctx context.Context, prompt ...string) error {
 
 	// Initialize
 	if _, err := c.q.initialize(); err != nil {
-		c.Close()
+		_ = c.Close()
 		return err
 	}
 

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -40,7 +40,7 @@ func basicStreaming(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Println("User: What is 2+2?")
 	if err := client.SendQuery(ctx, "What is 2+2?"); err != nil {
@@ -60,7 +60,7 @@ func multiTurnConversation(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// First turn
 	fmt.Println("User: What's the capital of France?")
@@ -91,7 +91,7 @@ func bashCommandExample(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Println("User: Run a bash echo command")
 	if err := client.SendQuery(ctx, "Run a bash echo command that says 'Hello from Go SDK!'"); err != nil {

--- a/sessions.go
+++ b/sessions.go
@@ -207,7 +207,7 @@ func readSessionLite(filePath string) *liteSessionFile {
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -218,8 +218,8 @@ func readSessionLite(filePath string) *liteSessionFile {
 	mtime := info.ModTime().UnixMilli()
 
 	headBuf := make([]byte, liteReadBufSize)
-	n, _ := f.Read(headBuf)
-	if n == 0 {
+	n, err := f.Read(headBuf)
+	if n == 0 || err != nil {
 		return nil
 	}
 	head := string(headBuf[:n])

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -243,7 +243,7 @@ func (t *SubprocessTransport) Close() error {
 	t.ready = false
 
 	if t.stdin != nil && !t.stdinClosed {
-		t.stdin.Close()
+		_ = t.stdin.Close()
 		t.stdinClosed = true
 	}
 


### PR DESCRIPTION
## Summary
- Handle unchecked error returns flagged by golangci-lint v2's stricter `errcheck` linter
- Fixes 16 `errcheck` violations and 1 `ineffassign` across `claude.go`, `client.go`, `sessions.go`, `subprocess_transport.go`, and `examples/streaming/main.go`
- Unblocks PR #8 (golangci-lint-action v6 → v9 bump)

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] CI lint job passes with current golangci-lint v1
- [ ] CI lint job will pass with golangci-lint v2 (PR #8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)