### PR TITLE
fix: handle unchecked client.Close() in example files

### DIFF
--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -107,7 +107,7 @@ func preToolUseExample(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Test 1: Command with forbidden pattern (blocked)
 	fmt.Println("Test 1: Trying a command that should be blocked...")
@@ -148,7 +148,7 @@ func userPromptSubmitExample(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Println("User: What's my favorite color?")
 	if err := client.SendQuery(ctx, "What's my favorite color?"); err != nil {
@@ -176,7 +176,7 @@ func postToolUseExample(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Println("User: Run a command that will produce an error: ls /nonexistent_directory")
 	if err := client.SendQuery(ctx, "Run this command: ls /nonexistent_directory"); err != nil {

--- a/examples/mcp_calculator/main.go
+++ b/examples/mcp_calculator/main.go
@@ -127,7 +127,7 @@ func main() {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Println("User: What is (3 + 4) * 5, and what's the square root of the result?")
 	if err := client.SendQuery(ctx, "What is (3 + 4) * 5, and what's the square root of the result? Use the calculator tools."); err != nil {

--- a/examples/tool_permissions/main.go
+++ b/examples/tool_permissions/main.go
@@ -67,7 +67,7 @@ func basicPermissions(ctx context.Context) {
 	if err := client.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Test: safe command
 	fmt.Println("User: Run echo 'hello world'")


### PR DESCRIPTION
## Summary
- Fix 5 remaining `errcheck` violations for `client.Close()` in example files (`hooks`, `mcp_calculator`, `tool_permissions`)
- Completes the lint cleanup started in #11 to unblock PR #8 (golangci-lint v2)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes