### PR TITLE
docs: clarify AllowedTools as permission allowlist and update doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/Flohs/claude-agent-sdk-go.svg)](https://pkg.go.dev/github.com/Flohs/claude-agent-sdk-go)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Go SDK for Claude Agent. Communicates with the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) via subprocess stdio using a JSON-based bidirectional control protocol.
+Go SDK for Claude Agent. Communicates with the [Claude Code CLI](https://code.claude.com/docs) via subprocess stdio using a JSON-based bidirectional control protocol.
 
 ## Installation
 

--- a/hooks.go
+++ b/hooks.go
@@ -156,7 +156,7 @@ type HookContext struct {
 }
 
 // HookJSONOutput represents the output of a hook callback.
-// See https://docs.anthropic.com/en/docs/claude-code/hooks#advanced%3A-json-output
+// See https://code.claude.com/docs/en/hooks#advanced%3A-json-output
 type HookJSONOutput map[string]any
 
 // HookCallback is the function type for hook callbacks.

--- a/options.go
+++ b/options.go
@@ -125,13 +125,17 @@ type SandboxSettings struct {
 type Options struct {
 	// Tools is the base set of tools. Use []string for explicit list or *ToolsPreset for preset.
 	Tools any // []string | *ToolsPreset | nil
-	// AllowedTools lists additional tools to allow.
+	// AllowedTools is a permission allowlist that auto-approves the listed tools
+	// without invoking the CanUseTool callback. Tools not in this list fall through
+	// to PermissionMode + CanUseTool evaluation. This is NOT an availability filter —
+	// it does not restrict which tools are available, only which are pre-approved.
 	AllowedTools []string
 	// SystemPrompt configures the system prompt. Use StringPrompt or PresetPrompt.
 	SystemPrompt SystemPrompt
 	// McpServers maps server names to their config. Use map[string]McpServerConfig or a string/path.
 	McpServers any // map[string]McpServerConfig | string | nil
-	// PermissionMode controls tool execution permissions.
+	// PermissionMode controls tool execution permissions. Used as the fallback
+	// for tools not matched by AllowedTools or DisallowedTools.
 	PermissionMode PermissionMode
 	// ContinueConversation continues the most recent conversation.
 	ContinueConversation bool
@@ -141,7 +145,8 @@ type Options struct {
 	MaxTurns *int
 	// MaxBudgetUSD limits the total cost.
 	MaxBudgetUSD *float64
-	// DisallowedTools lists tools to disallow.
+	// DisallowedTools lists tools to explicitly deny. Takes precedence over
+	// AllowedTools — a tool in both lists will be denied.
 	DisallowedTools []string
 	// Model specifies the AI model to use.
 	Model string
@@ -167,7 +172,8 @@ type Options struct {
 	MaxBufferSize *int
 	// Stderr is a callback for stderr output from the CLI.
 	Stderr func(string)
-	// CanUseTool is a callback for tool permission requests.
+	// CanUseTool is a callback invoked for tool permission decisions when a tool
+	// is not matched by AllowedTools or DisallowedTools.
 	CanUseTool CanUseToolFunc
 	// Hooks configures hook callbacks.
 	Hooks map[HookEvent][]HookMatcher

--- a/permissions.go
+++ b/permissions.go
@@ -114,4 +114,5 @@ type ToolPermissionContext struct {
 }
 
 // CanUseToolFunc is the callback type for tool permission decisions.
+// It is invoked for tools not matched by AllowedTools or DisallowedTools.
 type CanUseToolFunc func(ctx context.Context, toolName string, input map[string]any, permCtx ToolPermissionContext) (PermissionResult, error)


### PR DESCRIPTION
## Summary

- Clarify that `AllowedTools` is a **permission allowlist** that auto-approves listed tools (not an availability filter). Tools not in the list fall through to `PermissionMode` + `CanUseTool` evaluation.
- Document `DisallowedTools` precedence over `AllowedTools`
- Clarify `CanUseTool` / `PermissionMode` as fallback for unmatched tools
- Update outdated `docs.anthropic.com` URLs to `code.claude.com`

Closes #19
Port of [anthropics/claude-agent-sdk-python#649](https://github.com/anthropics/claude-agent-sdk-python/pull/649)

## Changed files

- `options.go` — expanded doc comments for `AllowedTools`, `DisallowedTools`, `PermissionMode`, `CanUseTool`
- `permissions.go` — added clarification to `CanUseToolFunc`
- `hooks.go` — updated link `docs.anthropic.com` → `code.claude.com/docs/en/hooks`
- `README.md` — updated link `docs.anthropic.com` → `code.claude.com/docs`

## Test plan

- [x] `go build ./...` passes
- [ ] Verify updated URLs resolve correctly