### PR TITLE
fix: revert automatic CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING injection

### DIFF
--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -571,17 +571,6 @@ func findCLI() (string, error) {
 	}
 }
 
-// envSetDefault appends key=value to env only if key is not already present.
-func envSetDefault(env []string, key, value string) []string {
-	prefix := key + "="
-	for _, e := range env {
-		if strings.HasPrefix(e, prefix) {
-			return env
-		}
-	}
-	return append(env, key+"="+value)
-}
-
 var versionRegexp = regexp.MustCompile(`^([0-9]+\.[0-9]+\.[0-9]+)`)
 
 func checkClaudeVersion(cliPath string) {

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -174,16 +174,6 @@ func buildTestEnv(opts *Options) []string {
 	return env
 }
 
-func assertEnvContains(t *testing.T, env []string, entry string) {
-	t.Helper()
-	for _, e := range env {
-		if e == entry {
-			return
-		}
-	}
-	t.Errorf("env does not contain %q", entry)
-}
-
 func assertEnvNotContainsKey(t *testing.T, env []string, key string) {
 	t.Helper()
 	prefix := key + "="


### PR DESCRIPTION
## Summary

- Reverts the automatic `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING=1` env var injection when `IncludePartialMessages` is enabled
- The Python SDK reverted this in commit `21560e38` because it causes **400 errors** with API proxies and older models (non-Claude 4.6)
- Updates tests to verify the env var is no longer set

## Python Reference

Python SDK commit: `anthropics/claude-agent-sdk-python@21560e38` — Revert "fix: enable fine-grained tool streaming when include_partial_messages=True"

## Test plan

- [x] Existing tests updated and passing
- [ ] Verify `IncludePartialMessages: true` no longer injects the env var
- [ ] Verify no regressions with proxy setups

Closes #21