### PR TITLE
release: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - New examples: `include_partial_messages`, `tools_option`, `setting_sources`, `stderr_callback`, `plugins`, and `filesystem_agents`.
 - Extended `streaming` example with interrupt, server info, and timeout sub-examples.
 
+### Changed
+
+- Minimum Go version upgraded from 1.24 to 1.26.1. ([#37](https://github.com/Flohs/claude-agent-sdk-go/pull/37))
+
 ### Fixed
 
 - `CLAUDE_CODE_ENTRYPOINT` is now only set when not already present, allowing callers to provide custom entrypoint values. ([#29](https://github.com/Flohs/claude-agent-sdk-go/issues/29))


### PR DESCRIPTION
## Summary

- Move all Unreleased changelog entries to v1.0.0 (2026-03-18)

Once merged, tag the merge commit as `v1.0.0`.