### PR TITLE
ci: add govulncheck vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,18 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+
+  vuln:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
## Summary

- Add a `vuln` job to the CI pipeline that runs `govulncheck ./...` on every push and PR
- Catches known Go vulnerabilities in dependencies before they reach main