### PR TITLE
feat: add tag/created_at to SDKSessionInfo + GetSessionInfo

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 	"unicode"
 
 	"golang.org/x/text/unicode/norm"
@@ -536,15 +537,21 @@ func readSessionsFromDir(projectDir string, projectPath string) []SDKSessionInfo
 			sessionCwd = projectPath
 		}
 
+		tag := extractTagFromTranscript(lite.head, lite.tail)
+		createdAt := extractCreatedAtFromHead(lite.head)
+		fileSize := lite.size
+
 		results = append(results, SDKSessionInfo{
 			SessionID:    sessionID,
 			Summary:      summary,
 			LastModified: lite.mtime,
-			FileSize:     lite.size,
+			FileSize:     &fileSize,
 			CustomTitle:  customTitle,
 			FirstPrompt:  firstPrompt,
 			GitBranch:    gitBranch,
 			Cwd:          sessionCwd,
+			Tag:          tag,
+			CreatedAt:    createdAt,
 		})
 	}
 
@@ -919,6 +926,150 @@ func toSessionMessage(entry transcriptEntry) SessionMessage {
 		SessionID: sessionID,
 		Message:   entry["message"],
 	}
+}
+
+// extractTagFromTranscript scans transcript head and tail for the last {"type":"tag"} entry
+// and returns the tag value. Returns nil if no tag entry is found.
+func extractTagFromTranscript(head, tail string) *string {
+	// Search tail first (more recent), then head
+	for _, section := range []string{tail, head} {
+		var lastTag *string
+		for _, line := range strings.Split(section, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			// Quick check: must contain "type" and "tag" to be a tag entry
+			if !strings.Contains(line, `"type"`) {
+				continue
+			}
+			if !strings.Contains(line, `"tag"`) {
+				continue
+			}
+			var entry map[string]any
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				continue
+			}
+			if entry["type"] != "tag" {
+				continue
+			}
+			if tagVal, ok := entry["tag"].(string); ok {
+				lastTag = &tagVal
+			}
+		}
+		if lastTag != nil {
+			return lastTag
+		}
+	}
+	return nil
+}
+
+// extractCreatedAtFromHead extracts the timestamp from the first transcript entry.
+// Returns the timestamp in Unix milliseconds, or nil if not found.
+func extractCreatedAtFromHead(head string) *int64 {
+	for _, line := range strings.Split(head, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		// Look for a timestamp field
+		if ts, ok := entry["timestamp"].(string); ok && ts != "" {
+			// Parse ISO 8601 timestamp to Unix milliseconds
+			for _, layout := range []string{
+				"2006-01-02T15:04:05.000Z",
+				"2006-01-02T15:04:05Z",
+				"2006-01-02T15:04:05.000-07:00",
+				"2006-01-02T15:04:05-07:00",
+			} {
+				if t, err := time.Parse(layout, ts); err == nil {
+					ms := t.UnixMilli()
+					return &ms
+				}
+			}
+		}
+		// Also check for numeric timestamp
+		if ts, ok := entry["timestamp"].(float64); ok {
+			ms := int64(ts)
+			return &ms
+		}
+		// Only check the first valid JSON line
+		return nil
+	}
+	return nil
+}
+
+// GetSessionInfo retrieves session metadata for a single session by its ID.
+// It locates the JSONL file and parses it to extract metadata including
+// tag, created_at, summary, and other fields.
+// Returns nil and an error if the session is not found.
+func GetSessionInfo(sessionID string, directory ...string) (*SDKSessionInfo, error) {
+	if !isValidUUID(sessionID) {
+		return nil, fmt.Errorf("invalid session ID: %s", sessionID)
+	}
+
+	dir := ""
+	if len(directory) > 0 {
+		dir = directory[0]
+	}
+
+	filePath := findSessionFilePath(sessionID, dir)
+	if filePath == "" {
+		return nil, fmt.Errorf("session not found: %s", sessionID)
+	}
+
+	lite := readSessionLite(filePath)
+	if lite == nil {
+		return nil, fmt.Errorf("failed to read session file: %s", sessionID)
+	}
+
+	// Check for sidechain
+	firstNewline := strings.Index(lite.head, "\n")
+	firstLine := lite.head
+	if firstNewline >= 0 {
+		firstLine = lite.head[:firstNewline]
+	}
+	if strings.Contains(firstLine, `"isSidechain":true`) || strings.Contains(firstLine, `"isSidechain": true`) {
+		return nil, fmt.Errorf("session not found: %s", sessionID)
+	}
+
+	customTitle := extractLastJSONStringField(lite.tail, "customTitle")
+	firstPrompt := extractFirstPromptFromHead(lite.head)
+
+	summary := customTitle
+	if summary == "" {
+		summary = extractLastJSONStringField(lite.tail, "summary")
+	}
+	if summary == "" {
+		summary = firstPrompt
+	}
+
+	gitBranch := extractLastJSONStringField(lite.tail, "gitBranch")
+	if gitBranch == "" {
+		gitBranch = extractJSONStringField(lite.head, "gitBranch")
+	}
+
+	sessionCwd := extractJSONStringField(lite.head, "cwd")
+
+	tag := extractTagFromTranscript(lite.head, lite.tail)
+	createdAt := extractCreatedAtFromHead(lite.head)
+	fileSize := lite.size
+
+	return &SDKSessionInfo{
+		SessionID:    sessionID,
+		Summary:      summary,
+		LastModified: lite.mtime,
+		FileSize:     &fileSize,
+		CustomTitle:  customTitle,
+		FirstPrompt:  firstPrompt,
+		GitBranch:    gitBranch,
+		Cwd:          sessionCwd,
+		Tag:          tag,
+		CreatedAt:    createdAt,
+	}, nil
 }
 
 // findSessionFilePath locates the JSONL file for a given session ID.

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -921,8 +921,8 @@ func TestListSessions_LargeFileHeadTailSplit(t *testing.T) {
 	if s.GitBranch != "main" {
 		t.Errorf("expected git branch 'main', got %q", s.GitBranch)
 	}
-	if s.FileSize <= int64(liteReadBufSize) {
-		t.Errorf("expected file size > %d, got %d", liteReadBufSize, s.FileSize)
+	if s.FileSize == nil || *s.FileSize <= int64(liteReadBufSize) {
+		t.Errorf("expected file size > %d, got %v", liteReadBufSize, s.FileSize)
 	}
 }
 
@@ -2154,5 +2154,282 @@ func TestRenameSession_JSONLFormat(t *testing.T) {
 	}
 	if entry["sessionId"] != sessionID {
 		t.Errorf("expected sessionId %q, got %v", sessionID, entry["sessionId"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetSessionInfo tests
+// ---------------------------------------------------------------------------
+
+func TestGetSessionInfo_Basic(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello Claude"}}`,
+		makeAssistantLine("a1", "u1", "Hi there!"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	info, err := GetSessionInfo(sessionID, "/test/get-info")
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil session info")
+	}
+	if info.SessionID != sessionID {
+		t.Errorf("expected session ID %s, got %s", sessionID, info.SessionID)
+	}
+	if info.FirstPrompt != "Hello Claude" {
+		t.Errorf("expected first prompt 'Hello Claude', got %q", info.FirstPrompt)
+	}
+	if info.FileSize == nil {
+		t.Error("expected non-nil FileSize")
+	}
+}
+
+func TestGetSessionInfo_WithTag(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info-tag")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello"}}`,
+		makeAssistantLine("a1", "u1", "Hi!"),
+		`{"type":"tag","tag":"my-feature-tag","sessionId":"` + sessionID + `"}`,
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	info, err := GetSessionInfo(sessionID, "/test/get-info-tag")
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info.Tag == nil {
+		t.Fatal("expected non-nil Tag")
+	}
+	if *info.Tag != "my-feature-tag" {
+		t.Errorf("expected tag 'my-feature-tag', got %q", *info.Tag)
+	}
+}
+
+func TestGetSessionInfo_TagOnlyFromTagType(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info-tag-type")
+
+	// Include a user message that mentions "tag" in its content — should NOT be picked up
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"please tag this"}}`,
+		makeAssistantLine("a1", "u1", "Done!"),
+		// Entry with a "tag" key but type is NOT "tag" — should NOT be picked up
+		`{"type":"user","uuid":"u2","parentUuid":"a1","message":{"role":"user","content":"result"},"tag":"not-this-one"}`,
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	info, err := GetSessionInfo(sessionID, "/test/get-info-tag-type")
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info.Tag != nil {
+		t.Errorf("expected nil Tag (no type:tag entry), got %q", *info.Tag)
+	}
+}
+
+func TestGetSessionInfo_CreatedAt(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info-created")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello"}}`,
+		makeAssistantLine("a1", "u1", "Hi!"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	info, err := GetSessionInfo(sessionID, "/test/get-info-created")
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info.CreatedAt == nil {
+		t.Fatal("expected non-nil CreatedAt")
+	}
+	// 2025-01-15T10:30:00.000Z in Unix milliseconds
+	expected := int64(1736937000000)
+	if *info.CreatedAt != expected {
+		t.Errorf("expected CreatedAt %d, got %d", expected, *info.CreatedAt)
+	}
+}
+
+func TestGetSessionInfo_CreatedAtNumericTimestamp(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info-created-num")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":1736937000000,"message":{"role":"user","content":"Hello"}}`,
+		makeAssistantLine("a1", "u1", "Hi!"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	info, err := GetSessionInfo(sessionID, "/test/get-info-created-num")
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info.CreatedAt == nil {
+		t.Fatal("expected non-nil CreatedAt")
+	}
+	if *info.CreatedAt != 1736937000000 {
+		t.Errorf("expected CreatedAt 1736937000000, got %d", *info.CreatedAt)
+	}
+}
+
+func TestGetSessionInfo_NoTimestamp(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info-no-ts")
+
+	content := strings.Join([]string{
+		makeUserLine("u1", "", "Hello"),
+		makeAssistantLine("a1", "u1", "Hi!"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	info, err := GetSessionInfo(sessionID, "/test/get-info-no-ts")
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info.CreatedAt != nil {
+		t.Errorf("expected nil CreatedAt, got %d", *info.CreatedAt)
+	}
+}
+
+func TestGetSessionInfo_NotFound(t *testing.T) {
+	setupTestProjectDir(t, "/test/get-info-notfound")
+
+	_, err := GetSessionInfo(testUUID1, "/test/get-info-notfound")
+	if err == nil {
+		t.Error("expected error for non-existent session")
+	}
+}
+
+func TestGetSessionInfo_InvalidUUID(t *testing.T) {
+	_, err := GetSessionInfo("not-a-uuid")
+	if err == nil {
+		t.Error("expected error for invalid UUID")
+	}
+}
+
+func TestGetSessionInfo_NoDirectory(t *testing.T) {
+	sessionID := testUUID1
+	projDir := setupTestProjectDir(t, "/test/get-info-nodir")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello"}}`,
+		makeAssistantLine("a1", "u1", "Hi!"),
+		`{"type":"tag","tag":"test-tag","sessionId":"` + sessionID + `"}`,
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	// Call without directory — should search all project dirs
+	info, err := GetSessionInfo(sessionID)
+	if err != nil {
+		t.Fatalf("GetSessionInfo failed: %v", err)
+	}
+	if info.SessionID != sessionID {
+		t.Errorf("expected session ID %s, got %s", sessionID, info.SessionID)
+	}
+	if info.Tag == nil || *info.Tag != "test-tag" {
+		t.Error("expected tag 'test-tag'")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListSessions tag/created_at integration tests
+// ---------------------------------------------------------------------------
+
+func TestListSessions_TagExtraction(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/list-tag")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello"}}`,
+		makeAssistantLine("a1", "u1", "Hi!"),
+		`{"type":"tag","tag":"feature-x","sessionId":"` + testUUID1 + `"}`,
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, testUUID1, content)
+
+	sessions, err := ListSessions(ListSessionsOptions{
+		Directory:        "/test/list-tag",
+		IncludeWorktrees: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].Tag == nil {
+		t.Fatal("expected non-nil Tag")
+	}
+	if *sessions[0].Tag != "feature-x" {
+		t.Errorf("expected tag 'feature-x', got %q", *sessions[0].Tag)
+	}
+}
+
+func TestListSessions_CreatedAtExtraction(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/list-created")
+
+	content := strings.Join([]string{
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello"}}`,
+		makeAssistantLine("a1", "u1", "Hi!"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, testUUID1, content)
+
+	sessions, err := ListSessions(ListSessionsOptions{
+		Directory:        "/test/list-created",
+		IncludeWorktrees: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].CreatedAt == nil {
+		t.Fatal("expected non-nil CreatedAt")
+	}
+	expected := int64(1736937000000)
+	if *sessions[0].CreatedAt != expected {
+		t.Errorf("expected CreatedAt %d, got %d", expected, *sessions[0].CreatedAt)
+	}
+}
+
+func TestExtractTagFromTranscript_OnlyTagType(t *testing.T) {
+	// A line with type "user" that has a "tag" field should NOT be extracted
+	head := `{"type":"user","uuid":"u1","tag":"wrong","message":{"role":"user","content":"hi"}}` + "\n"
+	tail := head
+
+	tag := extractTagFromTranscript(head, tail)
+	if tag != nil {
+		t.Errorf("expected nil tag, got %q", *tag)
+	}
+}
+
+func TestExtractTagFromTranscript_LastTagWins(t *testing.T) {
+	head := strings.Join([]string{
+		`{"type":"tag","tag":"first-tag","sessionId":"s1"}`,
+		`{"type":"tag","tag":"second-tag","sessionId":"s1"}`,
+	}, "\n") + "\n"
+	tail := head
+
+	tag := extractTagFromTranscript(head, tail)
+	if tag == nil {
+		t.Fatal("expected non-nil tag")
+	}
+	if *tag != "second-tag" {
+		t.Errorf("expected 'second-tag', got %q", *tag)
+	}
+}
+
+func TestExtractCreatedAtFromHead_NoTimestamp(t *testing.T) {
+	head := `{"type":"user","uuid":"u1","message":{"role":"user","content":"hello"}}` + "\n"
+	result := extractCreatedAtFromHead(head)
+	if result != nil {
+		t.Errorf("expected nil, got %d", *result)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -193,16 +193,18 @@ type RateLimitEvent struct {
 
 func (RateLimitEvent) messageMarker() {}
 
-// SDKSessionInfo contains session metadata returned by ListSessions.
+// SDKSessionInfo contains session metadata returned by ListSessions and GetSessionInfo.
 type SDKSessionInfo struct {
 	SessionID    string `json:"session_id"`
 	Summary      string `json:"summary"`
 	LastModified int64  `json:"last_modified"`
-	FileSize     int64  `json:"file_size"`
+	FileSize     *int64 `json:"file_size,omitempty"`
 	CustomTitle  string `json:"custom_title,omitempty"`
 	FirstPrompt  string `json:"first_prompt,omitempty"`
 	GitBranch    string `json:"git_branch,omitempty"`
 	Cwd          string `json:"cwd,omitempty"`
+	Tag          *string `json:"tag,omitempty"`
+	CreatedAt    *int64  `json:"created_at,omitempty"`
 }
 
 // SessionMessage represents a user or assistant message from a session transcript.


### PR DESCRIPTION
## Summary

- Add `Tag *string` and `CreatedAt *int64` fields to `SDKSessionInfo`
- Make `FileSize` optional (`*int64`)
- Add `GetSessionInfo(sessionID, ...directory)` public function for single-session lookup
- Extract tag only from `type:"tag"` transcript entries; created_at from first entry's timestamp

Closes #46

Ports [anthropics/claude-agent-sdk-python#667](https://github.com/anthropics/claude-agent-sdk-python/pull/667) (commit f144dcc).

## Test plan

- [x] `GetSessionInfo` returns correct metadata for known session
- [x] Tag extracted only from `type:"tag"` entries, not from other entries with a `tag` key
- [x] `CreatedAt` parsed from ISO 8601 string and numeric timestamp formats
- [x] Returns error for non-existent session and invalid UUID
- [x] `ListSessions` populates tag and created_at fields
- [x] All existing tests continue to pass