### PR TITLE
fix: wait for graceful process exit before signaling in Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `ReceiveResponse` and `ReceiveMessages` now check `ctx.Done()` in the inner receive loop, fixing indefinite hangs when context is cancelled while waiting for subprocess messages. ([#48](https://github.com/Flohs/claude-agent-sdk-go/pull/48))
 - `SendQuery` now checks `transport.IsReady()` before writing, returning an error if the subprocess has exited instead of silently writing to a dead pipe. ([#48](https://github.com/Flohs/claude-agent-sdk-go/pull/48))
 - `Interrupt` now respects the caller's context for both deadline expiry and explicit cancellation, and uses a 30-second default timeout (down from 60s). ([#48](https://github.com/Flohs/claude-agent-sdk-go/pull/48))
+- `Close()` now waits up to 5 seconds for the subprocess to exit naturally after closing stdin before sending SIGINT, preventing loss of the last assistant message when the CLI is still writing the session file. Aligns with Python SDK fix [anthropics/claude-agent-sdk-python@40cc6f5](https://github.com/anthropics/claude-agent-sdk-python/commit/40cc6f5). ([#49](https://github.com/Flohs/claude-agent-sdk-go/issues/49))
 
 ## [1.1.0] - 2026-03-20
 

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -250,14 +250,21 @@ func (t *SubprocessTransport) Close() error {
 	}
 
 	if t.cmd != nil && t.cmd.Process != nil {
-		_ = t.cmd.Process.Signal(os.Interrupt)
-		// Give it a moment to exit gracefully
 		done := make(chan error, 1)
 		go func() { done <- t.cmd.Wait() }()
+		// Wait for process to exit naturally after stdin close
 		select {
 		case <-done:
+			// Process exited cleanly — no signal needed
 		case <-time.After(5 * time.Second):
-			_ = t.cmd.Process.Kill()
+			// Grace period expired — escalate to SIGINT
+			_ = t.cmd.Process.Signal(os.Interrupt)
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				_ = t.cmd.Process.Kill()
+				<-done
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `Close()` now waits up to 5s for the subprocess to exit naturally after closing stdin before sending SIGINT, then another 5s before escalating to SIGKILL
- Previously SIGINT was sent immediately, which could interrupt the CLI while writing the session file, causing the last assistant message to be lost
- Aligns with Python SDK fix: https://github.com/anthropics/claude-agent-sdk-python/commit/40cc6f5

## Test plan

- [ ] Verify `Close()` allows natural exit when process terminates quickly after stdin close
- [ ] Verify SIGINT is sent after 5s if process hasn't exited
- [ ] Verify SIGKILL is sent after another 5s if SIGINT doesn't work
- [ ] Run `go test ./...` — all tests pass

Fixes #49