### PR TITLE
chore: bump minimum Claude CLI version from 2.0.0 to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - **Breaking:** `SDKSessionInfo.FileSize` changed from `int64` to `*int64` to align with the Python SDK. ([#46](https://github.com/Flohs/claude-agent-sdk-go/issues/46))
+- Minimum Claude CLI version bumped from `2.0.0` to `2.1.0` to ensure compatibility with features like skills, memory, mcpServers in agent definitions, typed `RateLimitEvent`, and `GetSessionInfo` with `tag/created_at`. ([#50](https://github.com/Flohs/claude-agent-sdk-go/issues/50))
 
 ### Fixed
 

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultMaxBufferSize       = 1024 * 1024 // 1MB
-	minimumClaudeCodeVersion   = "2.0.0"
+	minimumClaudeCodeVersion   = "2.1.0"
 	sdkVersion                 = "1.1.0"
 )
 


### PR DESCRIPTION
## Summary

- Bumps `minimumClaudeCodeVersion` from `2.0.0` to `2.1.0`
- The SDK supports features (skills, memory, mcpServers in agent definitions, typed `RateLimitEvent`, `GetSessionInfo` with `tag/created_at`) introduced after CLI 2.0.0
- The Python SDK currently bundles CLI v2.1.83

## Test plan

- [ ] Verify warning is emitted for CLI versions below 2.1.0
- [ ] Verify no warning for CLI versions >= 2.1.0
- [ ] Run `go test ./...` — all tests pass

Closes #50