### PR TITLE
feat: add GetContextUsage() method for context window usage breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `GetContextUsage` method on `Client` to query context window utilization by category. Port of Python SDK v0.1.52. ([#53](https://github.com/Flohs/claude-agent-sdk-go/issues/53))
+
 ## [1.2.0] - 2026-03-25
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -213,6 +213,14 @@ func (c *Client) GetMcpStatus(ctx context.Context) (*McpStatusResponse, error) {
 	return c.q.getMcpStatus()
 }
 
+// GetContextUsage returns the current context window usage breakdown.
+func (c *Client) GetContextUsage(ctx context.Context) (*ContextUsage, error) {
+	if c.q == nil {
+		return nil, &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+	return c.q.getContextUsage()
+}
+
 // ReconnectMcpServer reconnects a disconnected or failed MCP server.
 func (c *Client) ReconnectMcpServer(ctx context.Context, name string) error {
 	if c.q == nil {

--- a/query.go
+++ b/query.go
@@ -533,6 +533,24 @@ func (q *query) getMcpStatus() (*McpStatusResponse, error) {
 	return &status, nil
 }
 
+func (q *query) getContextUsage() (*ContextUsage, error) {
+	resp, err := q.sendControlRequest(map[string]any{"subtype": "get_context_usage"}, 60*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var usage ContextUsage
+	if err := json.Unmarshal(data, &usage); err != nil {
+		return nil, err
+	}
+	return &usage, nil
+}
+
 func (q *query) reconnectMcpServer(serverName string) error {
 	_, err := q.sendControlRequest(map[string]any{
 		"subtype":    "mcp_reconnect",

--- a/types.go
+++ b/types.go
@@ -193,6 +193,13 @@ type RateLimitEvent struct {
 
 func (RateLimitEvent) messageMarker() {}
 
+// ContextUsage contains context window utilization broken down by category.
+type ContextUsage struct {
+	TotalTokens     int            `json:"total_tokens"`
+	UsedTokens      int            `json:"used_tokens"`
+	UsageByCategory map[string]int `json:"usage_by_category,omitempty"`
+}
+
 // SDKSessionInfo contains session metadata returned by ListSessions and GetSessionInfo.
 type SDKSessionInfo struct {
 	SessionID    string `json:"session_id"`


### PR DESCRIPTION
## Summary

- Adds `GetContextUsage(ctx)` method to `Client` that queries context window utilization by category via a `get_context_usage` control request
- Adds `ContextUsage` response struct with `TotalTokens`, `UsedTokens`, and `UsageByCategory` fields
- Follows the same pattern as existing `GetMcpStatus()`

Closes #53

## Test plan

- [ ] Verify `GetContextUsage` returns a valid response when connected to CLI >= 2.1.0
- [ ] Verify it returns a `ConnectionError` when called before `Connect()`