### PR TITLE
feat: add TaskBudget option for token budget management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `DeleteSession` function to delete a session's transcript file. ([#54](https://github.com/Flohs/claude-agent-sdk-go/issues/54))
 - `ForkSession` function to create a copy of a session transcript with a new session ID. ([#54](https://github.com/Flohs/claude-agent-sdk-go/issues/54))
 - `Offset` field on `ListSessionsOptions` for offset-based pagination. ([#54](https://github.com/Flohs/claude-agent-sdk-go/issues/54))
+- `TaskBudget` option for per-task token budget management via `--task-budget` CLI flag. Port of Python SDK v0.1.51. ([#55](https://github.com/Flohs/claude-agent-sdk-go/issues/55))
 
 ## [1.2.0] - 2026-03-25
 

--- a/options.go
+++ b/options.go
@@ -148,6 +148,8 @@ type Options struct {
 	MaxTurns *int
 	// MaxBudgetUSD limits the total cost.
 	MaxBudgetUSD *float64
+	// TaskBudget sets a token budget per task.
+	TaskBudget *int
 	// DisallowedTools lists tools to explicitly deny. Takes precedence over
 	// AllowedTools — a tool in both lists will be denied.
 	DisallowedTools []string

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -364,6 +364,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--max-budget-usd", strconv.FormatFloat(*opts.MaxBudgetUSD, 'f', -1, 64))
 	}
 
+	if opts.TaskBudget != nil {
+		cmd = append(cmd, "--task-budget", strconv.Itoa(*opts.TaskBudget))
+	}
+
 	if len(opts.DisallowedTools) > 0 {
 		cmd = append(cmd, "--disallowedTools", strings.Join(opts.DisallowedTools, ","))
 	}


### PR DESCRIPTION
## Summary

- Adds `TaskBudget *int` field to `Options`
- Passes `--task-budget <value>` to CLI when set

Closes #55

## Test plan

- [ ] Verify `--task-budget` flag appears in CLI args when `TaskBudget` is set
- [ ] Verify flag is omitted when `TaskBudget` is nil