### PR TITLE
feat: add SessionID option to specify custom session IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `ForkSession` function to create a copy of a session transcript with a new session ID. ([#54](https://github.com/Flohs/claude-agent-sdk-go/issues/54))
 - `Offset` field on `ListSessionsOptions` for offset-based pagination. ([#54](https://github.com/Flohs/claude-agent-sdk-go/issues/54))
 - `TaskBudget` option for per-task token budget management via `--task-budget` CLI flag. Port of Python SDK v0.1.51. ([#55](https://github.com/Flohs/claude-agent-sdk-go/issues/55))
+- `SessionID` option to specify a custom session ID for conversations. Port of Python SDK v0.1.52. ([#56](https://github.com/Flohs/claude-agent-sdk-go/issues/56))
 
 ## [1.2.0] - 2026-03-25
 

--- a/options.go
+++ b/options.go
@@ -144,6 +144,8 @@ type Options struct {
 	ContinueConversation bool
 	// Resume resumes a specific session by ID.
 	Resume string
+	// SessionID specifies a custom session ID for the conversation.
+	SessionID string
 	// MaxTurns limits the number of conversation turns.
 	MaxTurns *int
 	// MaxBudgetUSD limits the total cost.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -404,6 +404,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--resume", opts.Resume)
 	}
 
+	if opts.SessionID != "" {
+		cmd = append(cmd, "--session-id", opts.SessionID)
+	}
+
 	// Settings and sandbox
 	settingsValue := t.buildSettingsValue()
 	if settingsValue != "" {


### PR DESCRIPTION
## Summary

- Adds `SessionID string` field to `Options`
- Passes `--session-id <value>` to CLI when set

Closes #56

## Test plan

- [ ] Verify `--session-id` flag appears in CLI args when `SessionID` is set
- [ ] Verify flag is omitted when `SessionID` is empty