### PR TITLE
feat: expose ToolUseID and AgentID in ToolPermissionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `Offset` field on `ListSessionsOptions` for offset-based pagination. ([#54](https://github.com/Flohs/claude-agent-sdk-go/issues/54))
 - `TaskBudget` option for per-task token budget management via `--task-budget` CLI flag. Port of Python SDK v0.1.51. ([#55](https://github.com/Flohs/claude-agent-sdk-go/issues/55))
 - `SessionID` option to specify a custom session ID for conversations. Port of Python SDK v0.1.52. ([#56](https://github.com/Flohs/claude-agent-sdk-go/issues/56))
+- `ToolUseID` and `AgentID` fields on `ToolPermissionContext` to identify which tool-use and sub-agent is requesting permission. Port of Python SDK v0.1.52. ([#57](https://github.com/Flohs/claude-agent-sdk-go/issues/57))
 
 ## [1.2.0] - 2026-03-25
 

--- a/permissions.go
+++ b/permissions.go
@@ -111,6 +111,10 @@ func (PermissionResultDeny) permissionResultMarker() {}
 // ToolPermissionContext provides context for tool permission callbacks.
 type ToolPermissionContext struct {
 	Suggestions []PermissionUpdate
+	// ToolUseID is the ID of the tool use that triggered this permission request.
+	ToolUseID string
+	// AgentID is the ID of the sub-agent requesting permission, if applicable.
+	AgentID string
 }
 
 // CanUseToolFunc is the callback type for tool permission decisions.

--- a/query.go
+++ b/query.go
@@ -264,7 +264,10 @@ func (q *query) handleCanUseTool(request map[string]any) (map[string]any, error)
 	input, _ := request["input"].(map[string]any)
 	originalInput := input
 
-	permCtx := ToolPermissionContext{}
+	permCtx := ToolPermissionContext{
+		ToolUseID: stringField(request, "tool_use_id"),
+		AgentID:   stringField(request, "agent_id"),
+	}
 	if suggestions, ok := request["permission_suggestions"].([]any); ok {
 		for _, s := range suggestions {
 			if sm, ok := s.(map[string]any); ok {


### PR DESCRIPTION
## Summary

- Adds `ToolUseID` and `AgentID` fields to `ToolPermissionContext`
- Populates them from the `can_use_tool` control request in `handleCanUseTool()`
- Enables permission callbacks to identify which sub-agent and tool-use is requesting permission

Closes #57

## Test plan

- [ ] Verify `ToolUseID` and `AgentID` are populated in `CanUseTool` callbacks
- [ ] Verify backward compatibility (empty strings when fields not present in request)