### PR TITLE
feat: add missing AgentDefinition fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `TaskBudget` option for per-task token budget management via `--task-budget` CLI flag. Port of Python SDK v0.1.51. ([#55](https://github.com/Flohs/claude-agent-sdk-go/issues/55))
 - `SessionID` option to specify a custom session ID for conversations. Port of Python SDK v0.1.52. ([#56](https://github.com/Flohs/claude-agent-sdk-go/issues/56))
 - `ToolUseID` and `AgentID` fields on `ToolPermissionContext` to identify which tool-use and sub-agent is requesting permission. Port of Python SDK v0.1.52. ([#57](https://github.com/Flohs/claude-agent-sdk-go/issues/57))
+- `Background`, `Effort`, `PermissionMode`, `DisallowedTools`, `MaxTurns`, and `InitialPrompt` fields on `AgentDefinition` for full agent configuration parity. Port of Python SDK v0.1.51/v0.1.53. ([#58](https://github.com/Flohs/claude-agent-sdk-go/issues/58))
 
 ## [1.2.0] - 2026-03-25
 

--- a/options.go
+++ b/options.go
@@ -61,13 +61,19 @@ type ToolsPreset struct {
 
 // AgentDefinition is an agent definition configuration.
 type AgentDefinition struct {
-	Description string   `json:"description"`
-	Prompt      string   `json:"prompt"`
-	Tools       []string `json:"tools,omitempty"`
-	Model       string   `json:"model,omitempty"` // "sonnet", "opus", "haiku", "inherit"
-	Skills      []string `json:"skills,omitempty"`
-	Memory      string   `json:"memory,omitempty"` // "user" | "project" | "local"
-	MCPServers  []any    `json:"mcpServers,omitempty"`
+	Description     string   `json:"description"`
+	Prompt          string   `json:"prompt"`
+	Tools           []string `json:"tools,omitempty"`
+	Model           string   `json:"model,omitempty"` // "sonnet", "opus", "haiku", "inherit"
+	Skills          []string `json:"skills,omitempty"`
+	Memory          string   `json:"memory,omitempty"` // "user" | "project" | "local"
+	MCPServers      []any    `json:"mcpServers,omitempty"`
+	Background      bool     `json:"background,omitempty"`
+	Effort          string   `json:"effort,omitempty"`
+	PermissionMode  string   `json:"permissionMode,omitempty"`
+	DisallowedTools []string `json:"disallowedTools,omitempty"`
+	MaxTurns        *int     `json:"maxTurns,omitempty"`
+	InitialPrompt   string   `json:"initialPrompt,omitempty"`
 }
 
 // ThinkingConfig is the interface for thinking configuration.

--- a/query.go
+++ b/query.go
@@ -136,6 +136,24 @@ func newQuery(cfg queryConfig) *query {
 			if len(def.MCPServers) > 0 {
 				m["mcpServers"] = def.MCPServers
 			}
+			if def.Background {
+				m["background"] = true
+			}
+			if def.Effort != "" {
+				m["effort"] = def.Effort
+			}
+			if def.PermissionMode != "" {
+				m["permissionMode"] = def.PermissionMode
+			}
+			if len(def.DisallowedTools) > 0 {
+				m["disallowedTools"] = def.DisallowedTools
+			}
+			if def.MaxTurns != nil {
+				m["maxTurns"] = *def.MaxTurns
+			}
+			if def.InitialPrompt != "" {
+				m["initialPrompt"] = def.InitialPrompt
+			}
 			q.agents[name] = m
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds six new fields to `AgentDefinition`: `Background` (bool), `Effort` (string), `PermissionMode` (string), `DisallowedTools` ([]string), `MaxTurns` (*int), `InitialPrompt` (string)
- Serializes new fields in agent config during `initialize()` control request

Closes #58

## Test plan

- [ ] Verify new fields are serialized in the initialize request when set
- [ ] Verify omitted when zero-valued (omitempty behavior)
- [ ] Verify `go build ./...` passes