### PR TITLE
feat: add SystemPromptFile option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `SessionID` option to specify a custom session ID for conversations. Port of Python SDK v0.1.52. ([#56](https://github.com/Flohs/claude-agent-sdk-go/issues/56))
 - `ToolUseID` and `AgentID` fields on `ToolPermissionContext` to identify which tool-use and sub-agent is requesting permission. Port of Python SDK v0.1.52. ([#57](https://github.com/Flohs/claude-agent-sdk-go/issues/57))
 - `Background`, `Effort`, `PermissionMode`, `DisallowedTools`, `MaxTurns`, and `InitialPrompt` fields on `AgentDefinition` for full agent configuration parity. Port of Python SDK v0.1.51/v0.1.53. ([#58](https://github.com/Flohs/claude-agent-sdk-go/issues/58))
+- `SystemPromptFile` option to load system prompts from a file via `--system-prompt-file` CLI flag. Mutually exclusive with `SystemPrompt`. Port of Python SDK v0.1.51. ([#59](https://github.com/Flohs/claude-agent-sdk-go/issues/59))
 
 ## [1.2.0] - 2026-03-25
 

--- a/options.go
+++ b/options.go
@@ -141,6 +141,9 @@ type Options struct {
 	AllowedTools []string
 	// SystemPrompt configures the system prompt. Use StringPrompt or PresetPrompt.
 	SystemPrompt SystemPrompt
+	// SystemPromptFile is a path to a file containing the system prompt.
+	// Mutually exclusive with SystemPrompt.
+	SystemPromptFile string
 	// McpServers maps server names to their config. Use map[string]McpServerConfig or a string/path.
 	McpServers any // map[string]McpServerConfig | string | nil
 	// PermissionMode controls tool execution permissions. Used as the fallback

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -325,7 +325,9 @@ func (t *SubprocessTransport) buildCommand() []string {
 	opts := t.options
 
 	// System prompt
-	if opts.SystemPrompt == nil {
+	if opts.SystemPromptFile != "" {
+		cmd = append(cmd, "--system-prompt-file", opts.SystemPromptFile)
+	} else if opts.SystemPrompt == nil {
 		cmd = append(cmd, "--system-prompt", "")
 	} else {
 		switch sp := opts.SystemPrompt.(type) {


### PR DESCRIPTION
## Summary

- Adds `SystemPromptFile string` field to `Options` (mutually exclusive with `SystemPrompt`)
- Passes `--system-prompt-file <path>` to CLI when set, taking precedence over `SystemPrompt`

Closes #59

## Test plan

- [ ] Verify `--system-prompt-file` flag appears when `SystemPromptFile` is set
- [ ] Verify `SystemPrompt` is ignored when `SystemPromptFile` is set
- [ ] Verify normal `SystemPrompt` behavior when `SystemPromptFile` is empty