### PR TITLE
fix: omit --setting-sources flag when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `Background`, `Effort`, `PermissionMode`, `DisallowedTools`, `MaxTurns`, and `InitialPrompt` fields on `AgentDefinition` for full agent configuration parity. Port of Python SDK v0.1.51/v0.1.53. ([#58](https://github.com/Flohs/claude-agent-sdk-go/issues/58))
 - `SystemPromptFile` option to load system prompts from a file via `--system-prompt-file` CLI flag. Mutually exclusive with `SystemPrompt`. Port of Python SDK v0.1.51. ([#59](https://github.com/Flohs/claude-agent-sdk-go/issues/59))
 
+### Fixed
+
+- `--setting-sources` flag is no longer sent when `SettingSources` is not explicitly configured, aligning with Python SDK v0.1.53 fix. Previously an empty string was always sent. ([#60](https://github.com/Flohs/claude-agent-sdk-go/issues/60))
+
 ## [1.2.0] - 2026-03-25
 
 ### Added

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -455,8 +455,6 @@ func (t *SubprocessTransport) buildCommand() []string {
 			sources[i] = string(s)
 		}
 		cmd = append(cmd, "--setting-sources", strings.Join(sources, ","))
-	} else {
-		cmd = append(cmd, "--setting-sources", "")
 	}
 
 	// Plugins

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -289,13 +289,18 @@ func assertContainsFlag(t *testing.T, cmd []string, flag string) {
 }
 
 func TestBuildCommand_SettingSources(t *testing.T) {
-	t.Run("nil setting sources sends empty", func(t *testing.T) {
+	t.Run("nil setting sources omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{
 			cliPath: "claude",
 			options: &Options{},
 		}
 		cmd := transport.buildCommand()
-		assertContains(t, cmd, "--setting-sources", "")
+		for _, arg := range cmd {
+			if arg == "--setting-sources" {
+				t.Error("--setting-sources flag should not be present when SettingSources is nil")
+				return
+			}
+		}
 	})
 
 	t.Run("explicit setting sources", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Removes the `else` branch that sent `--setting-sources ""` when `SettingSources` was nil
- The flag is now only included when explicitly configured
- Updates test that verified the old empty-string behavior

Closes #60

## Test plan

- [ ] Verify `--setting-sources` is absent from CLI args when `SettingSources` is nil
- [ ] Verify `--setting-sources user,project` works when explicitly set
- [ ] All existing tests pass