### PR TITLE
feat: implement control_cancel_request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - `--setting-sources` flag is no longer sent when `SettingSources` is not explicitly configured, aligning with Python SDK v0.1.53 fix. Previously an empty string was always sent. ([#60](https://github.com/Flohs/claude-agent-sdk-go/issues/60))
+- `control_cancel_request` messages from the CLI now properly cancel pending control requests instead of being silently ignored. Port of Python SDK v0.1.52. ([#61](https://github.com/Flohs/claude-agent-sdk-go/issues/61))
 
 ## [1.2.0] - 2026-03-25
 

--- a/query.go
+++ b/query.go
@@ -212,6 +212,15 @@ func (q *query) readMessages() {
 		}
 
 		if msgType == "control_cancel_request" {
+			requestID, _ := msg["request_id"].(string)
+			if requestID != "" {
+				q.pendingMu.Lock()
+				if ch, ok := q.pendingEvents[requestID]; ok {
+					q.pendingResults[requestID] = fmt.Errorf("request cancelled by CLI")
+					close(ch)
+				}
+				q.pendingMu.Unlock()
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- `control_cancel_request` messages from CLI now cancel the matching pending control request with an error, instead of being silently ignored
- Follows the same pattern as `control_response` handling

Closes #61

## Test plan

- [ ] Verify pending control requests are cancelled when CLI sends `control_cancel_request`
- [ ] Verify the error message indicates cancellation