### PR TITLE
fix: add missing Errors field to ResultMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `ToolUseID` and `AgentID` fields on `ToolPermissionContext` to identify which tool-use and sub-agent is requesting permission. Port of Python SDK v0.1.52. ([#57](https://github.com/Flohs/claude-agent-sdk-go/issues/57))
 - `Background`, `Effort`, `PermissionMode`, `DisallowedTools`, `MaxTurns`, and `InitialPrompt` fields on `AgentDefinition` for full agent configuration parity. Port of Python SDK v0.1.51/v0.1.53. ([#58](https://github.com/Flohs/claude-agent-sdk-go/issues/58))
 - `SystemPromptFile` option to load system prompts from a file via `--system-prompt-file` CLI flag. Mutually exclusive with `SystemPrompt`. Port of Python SDK v0.1.51. ([#59](https://github.com/Flohs/claude-agent-sdk-go/issues/59))
+- `Errors` field on `ResultMessage` to capture structured error information from the CLI. Port of Python SDK v0.1.51. ([#62](https://github.com/Flohs/claude-agent-sdk-go/issues/62))
 
 ### Fixed
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -187,6 +187,10 @@ func parseResultMessage(data map[string]any) (*ResultMessage, error) {
 		Result:        stringField(data, "result"),
 	}
 
+	if errors, ok := data["errors"].([]any); ok {
+		msg.Errors = errors
+	}
+
 	if cost, ok := data["total_cost_usd"].(float64); ok {
 		msg.TotalCostUSD = &cost
 	}

--- a/types.go
+++ b/types.go
@@ -142,6 +142,7 @@ type ResultMessage struct {
 	DurationMs       int            `json:"duration_ms"`
 	DurationAPIMs    int            `json:"duration_api_ms"`
 	IsError          bool           `json:"is_error"`
+	Errors           []any          `json:"errors,omitempty"`
 	NumTurns         int            `json:"num_turns"`
 	SessionID        string         `json:"session_id"`
 	StopReason       string         `json:"stop_reason,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `Errors []any` field to `ResultMessage`
- Populates it from the `errors` key in `parseResultMessage()`

Closes #62

## Test plan

- [ ] Verify `Errors` is populated when CLI sends a result with errors
- [ ] Verify `Errors` is nil when not present in CLI output