### PR TITLE
fix: filter CLAUDECODE env var from subprocess environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `--setting-sources` flag is no longer sent when `SettingSources` is not explicitly configured, aligning with Python SDK v0.1.53 fix. Previously an empty string was always sent. ([#60](https://github.com/Flohs/claude-agent-sdk-go/issues/60))
 - `control_cancel_request` messages from the CLI now properly cancel pending control requests instead of being silently ignored. Port of Python SDK v0.1.52. ([#61](https://github.com/Flohs/claude-agent-sdk-go/issues/61))
+- `CLAUDECODE` environment variable is now filtered from the subprocess environment to prevent interference with nested SDK/CLI instances. Port of Python SDK v0.1.51. ([#63](https://github.com/Flohs/claude-agent-sdk-go/issues/63))
 
 ## [1.2.0] - 2026-03-25
 

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -84,8 +84,12 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 	// Merge environment using layered ordering:
 	// 1. SDK defaults (overridable by system env or user env)
 	env := []string{"CLAUDE_CODE_ENTRYPOINT=sdk-go"}
-	// 2. System environment
-	env = append(env, os.Environ()...)
+	// 2. System environment (filter CLAUDECODE to prevent interference with nested instances)
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "CLAUDECODE=") {
+			env = append(env, e)
+		}
+	}
 	// 3. User-provided env vars (override defaults and system env)
 	for k, v := range t.options.Env {
 		env = append(env, k+"="+v)


### PR DESCRIPTION
## Summary

- Filters out `CLAUDECODE=` entries when building the subprocess environment
- Prevents nested SDK/CLI instances from interfering with each other

Closes #63

## Test plan

- [ ] Verify `CLAUDECODE` env var is not inherited by subprocess
- [ ] Verify all other env vars are still passed through