### PR TITLE
fix: skip non-JSON lines on CLI stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `--setting-sources` flag is no longer sent when `SettingSources` is not explicitly configured, aligning with Python SDK v0.1.53 fix. Previously an empty string was always sent. ([#60](https://github.com/Flohs/claude-agent-sdk-go/issues/60))
 - `control_cancel_request` messages from the CLI now properly cancel pending control requests instead of being silently ignored. Port of Python SDK v0.1.52. ([#61](https://github.com/Flohs/claude-agent-sdk-go/issues/61))
 - `CLAUDECODE` environment variable is now filtered from the subprocess environment to prevent interference with nested SDK/CLI instances. Port of Python SDK v0.1.51. ([#63](https://github.com/Flohs/claude-agent-sdk-go/issues/63))
+- Non-JSON lines on CLI stdout (e.g. native module warnings) are now skipped instead of accumulating in the JSON parse buffer. Port of Python SDK v0.1.51. ([#64](https://github.com/Flohs/claude-agent-sdk-go/issues/64))
 
 ## [1.2.0] - 2026-03-25
 

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -199,6 +199,11 @@ func (t *SubprocessTransport) ReadMessages(ctx context.Context) <-chan map[strin
 				continue
 			}
 
+			// Skip non-JSON lines when not accumulating a partial object
+			if jsonBuffer == "" && len(line) > 0 && line[0] != '{' {
+				continue
+			}
+
 			jsonBuffer += line
 
 			if len(jsonBuffer) > t.maxBufSize {


### PR DESCRIPTION
## Summary

- Lines not starting with `{` are now skipped when the JSON buffer is empty
- Prevents non-JSON output (native module warnings, debug output) from polluting the parse buffer

Closes #64

## Test plan

- [ ] Verify non-JSON lines (e.g. `Warning: ...`) are silently skipped
- [ ] Verify valid JSON messages still parse correctly
- [ ] Verify partial multi-line JSON still works