### PR TITLE
feat: preserve unknown fields on messages for forward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Background`, `Effort`, `PermissionMode`, `DisallowedTools`, `MaxTurns`, and `InitialPrompt` fields on `AgentDefinition` for full agent configuration parity. Port of Python SDK v0.1.51/v0.1.53. ([#58](https://github.com/Flohs/claude-agent-sdk-go/issues/58))
 - `SystemPromptFile` option to load system prompts from a file via `--system-prompt-file` CLI flag. Mutually exclusive with `SystemPrompt`. Port of Python SDK v0.1.51. ([#59](https://github.com/Flohs/claude-agent-sdk-go/issues/59))
 - `Errors` field on `ResultMessage` to capture structured error information from the CLI. Port of Python SDK v0.1.51. ([#62](https://github.com/Flohs/claude-agent-sdk-go/issues/62))
+- `RawData` field on `AssistantMessage` and `ResultMessage` preserving the full raw message map for forward compatibility with fields not yet modeled by the SDK. Port of Python SDK v0.1.51. ([#65](https://github.com/Flohs/claude-agent-sdk-go/issues/65))
 
 ### Fixed
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -110,6 +110,8 @@ func parseAssistantMessage(data map[string]any) (*AssistantMessage, error) {
 		msg.Usage = usage
 	}
 
+	msg.RawData = data
+
 	return msg, nil
 }
 
@@ -198,6 +200,8 @@ func parseResultMessage(data map[string]any) (*ResultMessage, error) {
 		msg.Usage = usage
 	}
 	msg.StructuredOutput = data["structured_output"]
+
+	msg.RawData = data
 
 	return msg, nil
 }

--- a/types.go
+++ b/types.go
@@ -72,6 +72,9 @@ type AssistantMessage struct {
 	ParentToolUseID string                `json:"parent_tool_use_id,omitempty"`
 	Error           AssistantMessageError `json:"error,omitempty"`
 	Usage           map[string]any        `json:"usage,omitempty"`
+	// RawData contains the full raw message data for forward compatibility
+	// with fields not yet modeled by the SDK.
+	RawData map[string]any `json:"-"`
 }
 
 func (AssistantMessage) messageMarker() {}
@@ -150,6 +153,9 @@ type ResultMessage struct {
 	Usage            map[string]any `json:"usage,omitempty"`
 	Result           string         `json:"result,omitempty"`
 	StructuredOutput any            `json:"structured_output,omitempty"`
+	// RawData contains the full raw message data for forward compatibility
+	// with fields not yet modeled by the SDK.
+	RawData map[string]any `json:"-"`
 }
 
 func (ResultMessage) messageMarker() {}


### PR DESCRIPTION
## Summary

- Adds `RawData map[string]any` field (tagged `json:"-"`) to `AssistantMessage` and `ResultMessage`
- Preserves the full raw message map so consumers can access new fields before the SDK adds typed support

Closes #65

## Test plan

- [ ] Verify `RawData` contains all original fields after parsing
- [ ] Verify `RawData` is not included when marshaling the struct to JSON
- [ ] Verify existing message parsing is unaffected