### PR TITLE
fix: add missing dontAsk permission mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `SystemPromptFile` option to load system prompts from a file via `--system-prompt-file` CLI flag. Mutually exclusive with `SystemPrompt`. Port of Python SDK v0.1.51. ([#59](https://github.com/Flohs/claude-agent-sdk-go/issues/59))
 - `Errors` field on `ResultMessage` to capture structured error information from the CLI. Port of Python SDK v0.1.51. ([#62](https://github.com/Flohs/claude-agent-sdk-go/issues/62))
 - `RawData` field on `AssistantMessage` and `ResultMessage` preserving the full raw message map for forward compatibility with fields not yet modeled by the SDK. Port of Python SDK v0.1.51. ([#65](https://github.com/Flohs/claude-agent-sdk-go/issues/65))
+- `PermissionModeDontAsk` constant for the `dontAsk` permission mode. Port of Python SDK v0.1.51. ([#66](https://github.com/Flohs/claude-agent-sdk-go/issues/66))
 
 ### Fixed
 

--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ const (
 	PermissionModeAcceptEdits       PermissionMode = "acceptEdits"
 	PermissionModePlan              PermissionMode = "plan"
 	PermissionModeBypassPermissions PermissionMode = "bypassPermissions"
+	PermissionModeDontAsk           PermissionMode = "dontAsk"
 )
 
 // SdkBeta represents beta feature flags.


### PR DESCRIPTION
## Summary

- Adds `PermissionModeDontAsk PermissionMode = "dontAsk"` constant

Closes #66

## Test plan

- [ ] Verify `PermissionModeDontAsk` can be used in `Options.PermissionMode`
- [ ] Verify it serializes correctly as `dontAsk` in CLI args