### PR TITLE
fix: propagate is_error flag from MCP tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `control_cancel_request` messages from the CLI now properly cancel pending control requests instead of being silently ignored. Port of Python SDK v0.1.52. ([#61](https://github.com/Flohs/claude-agent-sdk-go/issues/61))
 - `CLAUDECODE` environment variable is now filtered from the subprocess environment to prevent interference with nested SDK/CLI instances. Port of Python SDK v0.1.51. ([#63](https://github.com/Flohs/claude-agent-sdk-go/issues/63))
 - Non-JSON lines on CLI stdout (e.g. native module warnings) are now skipped instead of accumulating in the JSON parse buffer. Port of Python SDK v0.1.51. ([#64](https://github.com/Flohs/claude-agent-sdk-go/issues/64))
+- SDK MCP tool handler errors are now returned as MCP tool results with `isError: true` instead of JSONRPC protocol errors, conforming to the MCP specification. **Note:** code inspecting raw JSONRPC responses from SDK MCP tool handlers will see a `"result"` with `"isError": true` instead of a JSONRPC `"error"` object. Port of Python SDK v0.1.51. ([#67](https://github.com/Flohs/claude-agent-sdk-go/issues/67))
 
 ## [1.2.0] - 2026-03-25
 

--- a/mcp.go
+++ b/mcp.go
@@ -264,9 +264,11 @@ func (r *sdkMcpRouter) handleRequest(ctx context.Context, serverName string, mes
 			return map[string]any{
 				"jsonrpc": "2.0",
 				"id":      message["id"],
-				"error": map[string]any{
-					"code":    -32603,
-					"message": err.Error(),
+				"result": map[string]any{
+					"content": []map[string]any{
+						{"type": "text", "text": err.Error()},
+					},
+					"isError": true,
 				},
 			}
 		}


### PR DESCRIPTION
## Summary

- MCP tool handler errors now return a successful JSONRPC response with `isError: true` in the result content, instead of a JSONRPC protocol error
- Conforms to the MCP specification where tool execution errors are distinct from protocol errors

Closes #67

## Test plan

- [ ] Verify tool handler errors produce `{"result": {"content": [...], "isError": true}}` not `{"error": {...}}`
- [ ] Verify successful tool results are unchanged