### PR TITLE
feat: add MCP resource list and read support for SDK MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - `Errors` field on `ResultMessage` to capture structured error information from the CLI. Port of Python SDK v0.1.51. ([#62](https://github.com/Flohs/claude-agent-sdk-go/issues/62))
 - `RawData` field on `AssistantMessage` and `ResultMessage` preserving the full raw message map for forward compatibility with fields not yet modeled by the SDK. Port of Python SDK v0.1.51. ([#65](https://github.com/Flohs/claude-agent-sdk-go/issues/65))
 - `PermissionModeDontAsk` constant for the `dontAsk` permission mode. Port of Python SDK v0.1.51. ([#66](https://github.com/Flohs/claude-agent-sdk-go/issues/66))
+- `SdkMcpResource` and `SdkMcpResourceHandler` types for defining MCP server resources. ([#68](https://github.com/Flohs/claude-agent-sdk-go/issues/68))
+- `NewSdkMcpServerWithResources` constructor for creating MCP servers with both tools and resources. ([#68](https://github.com/Flohs/claude-agent-sdk-go/issues/68))
+- `resources/list` and `resources/read` MCP method handling in SDK MCP servers. Port of Python SDK v0.1.51. ([#68](https://github.com/Flohs/claude-agent-sdk-go/issues/68))
 
 ### Fixed
 

--- a/mcp.go
+++ b/mcp.go
@@ -75,9 +75,11 @@ func (c McpHTTPServerConfig) MarshalJSON() ([]byte, error) {
 
 // McpSdkServerConfig configures an in-process SDK MCP server.
 type McpSdkServerConfig struct {
-	Name    string
-	tools   []SdkMcpTool
-	version string
+	Name            string
+	tools           []SdkMcpTool
+	resources       []SdkMcpResource
+	resourceHandler SdkMcpResourceHandler
+	version         string
 }
 
 func (McpSdkServerConfig) mcpServerConfigMarker() {}
@@ -152,6 +154,17 @@ type SdkMcpTool struct {
 	Handler     SdkMcpToolHandler
 }
 
+// SdkMcpResource defines an SDK MCP resource.
+type SdkMcpResource struct {
+	URI         string
+	Name        string
+	Description string
+	MimeType    string
+}
+
+// SdkMcpResourceHandler is the handler function for reading an SDK MCP resource.
+type SdkMcpResourceHandler func(ctx context.Context, uri string) (string, string, error) // content, mimeType, error
+
 // NewSdkMcpServer creates an in-process MCP server configuration.
 func NewSdkMcpServer(name string, version string, tools []SdkMcpTool) *McpSdkServerConfig {
 	if version == "" {
@@ -161,6 +174,20 @@ func NewSdkMcpServer(name string, version string, tools []SdkMcpTool) *McpSdkSer
 		Name:    name,
 		tools:   tools,
 		version: version,
+	}
+}
+
+// NewSdkMcpServerWithResources creates an in-process MCP server configuration with tools and resources.
+func NewSdkMcpServerWithResources(name string, version string, tools []SdkMcpTool, resources []SdkMcpResource, resourceHandler SdkMcpResourceHandler) *McpSdkServerConfig {
+	if version == "" {
+		version = "1.0.0"
+	}
+	return &McpSdkServerConfig{
+		Name:            name,
+		tools:           tools,
+		resources:       resources,
+		resourceHandler: resourceHandler,
+		version:         version,
 	}
 }
 
@@ -203,14 +230,18 @@ func (r *sdkMcpRouter) handleRequest(ctx context.Context, serverName string, mes
 
 	switch method {
 	case "initialize":
+		capabilities := map[string]any{
+			"tools": map[string]any{},
+		}
+		if len(server.resources) > 0 {
+			capabilities["resources"] = map[string]any{}
+		}
 		return map[string]any{
 			"jsonrpc": "2.0",
 			"id":      message["id"],
 			"result": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"capabilities": map[string]any{
-					"tools": map[string]any{},
-				},
+				"capabilities":    capabilities,
 				"serverInfo": map[string]any{
 					"name":    server.Name,
 					"version": server.version,
@@ -276,6 +307,66 @@ func (r *sdkMcpRouter) handleRequest(ctx context.Context, serverName string, mes
 			"jsonrpc": "2.0",
 			"id":      message["id"],
 			"result":  result,
+		}
+
+	case "resources/list":
+		resourcesList := make([]map[string]any, len(server.resources))
+		for i, res := range server.resources {
+			resData := map[string]any{
+				"uri":  res.URI,
+				"name": res.Name,
+			}
+			if res.Description != "" {
+				resData["description"] = res.Description
+			}
+			if res.MimeType != "" {
+				resData["mimeType"] = res.MimeType
+			}
+			resourcesList[i] = resData
+		}
+		return map[string]any{
+			"jsonrpc": "2.0",
+			"id":      message["id"],
+			"result": map[string]any{
+				"resources": resourcesList,
+			},
+		}
+
+	case "resources/read":
+		uri, _ := params["uri"].(string)
+		if server.resourceHandler == nil {
+			return map[string]any{
+				"jsonrpc": "2.0",
+				"id":      message["id"],
+				"error": map[string]any{
+					"code":    -32601,
+					"message": "No resource handler configured",
+				},
+			}
+		}
+		content, mimeType, err := server.resourceHandler(ctx, uri)
+		if err != nil {
+			return map[string]any{
+				"jsonrpc": "2.0",
+				"id":      message["id"],
+				"error": map[string]any{
+					"code":    -32603,
+					"message": err.Error(),
+				},
+			}
+		}
+		return map[string]any{
+			"jsonrpc": "2.0",
+			"id":      message["id"],
+			"result": map[string]any{
+				"contents": []map[string]any{
+					{
+						"uri":      uri,
+						"mimeType": mimeType,
+						"text":     content,
+					},
+				},
+			},
 		}
 
 	case "notifications/initialized":


### PR DESCRIPTION
## Summary

- Adds `SdkMcpResource` struct and `SdkMcpResourceHandler` function type
- Adds `NewSdkMcpServerWithResources` constructor (existing `NewSdkMcpServer` unchanged)
- Adds `resources/list` and `resources/read` MCP method handling
- Advertises `resources` capability in MCP initialize response when resources are configured

Closes #68

## Test plan

- [ ] Verify `resources/list` returns registered resources
- [ ] Verify `resources/read` delegates to the resource handler
- [ ] Verify `NewSdkMcpServer` still works without resources (backward compatibility)
- [ ] Verify `initialize` response includes `resources` capability only when configured