### PR TITLE
chore: bump minimum CLI version to 2.1.90 (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Minimum Claude CLI version bumped from `2.1.0` to `2.1.90` to align with Python SDK and ensure compatibility with v1.3.0 features (TaskBudget, ForkSession, DeleteSession, GetContextUsage, control_cancel_request, Errors on ResultMessage). ([#88](https://github.com/Flohs/claude-agent-sdk-go/issues/88))
+
 ### Fixed
 
 - Prevent deadlock in `Query()` when many messages arrive before the result. When SDK MCP servers or hooks triggered >100 tool calls, the `messageCh` buffer filled before the consumer started draining, blocking `readMessages()` from ever reaching the `result` message. Port of Python SDK [anthropics/claude-agent-sdk-python#780](https://github.com/anthropics/claude-agent-sdk-python/pull/780). ([#85](https://github.com/Flohs/claude-agent-sdk-go/issues/85))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/Flohs/claude-agent-sdk-go
 **Prerequisites:**
 
 - Go 1.26+
-- Claude Code CLI (>= 2.0.0) installed: `npm install -g @anthropic-ai/claude-code`
+- Claude Code CLI (>= 2.1.90) installed: `npm install -g @anthropic-ai/claude-code`
   - Or specify a custom path: `Options{CLIPath: "/path/to/claude"}`
   - The SDK uses the bidirectional JSON streaming protocol (`--output-format stream-json`), which requires CLI version 2.0.0 or later. A version check runs automatically on connect and warns if the CLI is too old.
 
@@ -25,6 +25,8 @@ go get github.com/Flohs/claude-agent-sdk-go
 |---------|-------------------|
 | Base functionality (streaming JSON protocol) | >= 2.0.0 |
 | Fine-grained tool streaming (`IncludePartialMessages`) | >= 2.1.40 |
+| TaskBudget, ForkSession, DeleteSession, Errors on ResultMessage | >= 2.1.85 |
+| GetContextUsage, control_cancel_request handling | >= 2.1.87 |
 
 ## Quick Start
 

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultMaxBufferSize       = 1024 * 1024 // 1MB
-	minimumClaudeCodeVersion   = "2.1.0"
+	minimumClaudeCodeVersion   = "2.1.90"
 	sdkVersion                 = "1.3.0"
 )
 


### PR DESCRIPTION
Closes #88

## Summary

- Bump `minimumClaudeCodeVersion` from `2.1.0` to `2.1.90` to align with the Python SDK and ensure all v1.3.0 features are supported by the CLI
- Update README prerequisites and version compatibility table with new feature rows
- Update changelog

## Feature → CLI version mapping

| Feature | Minimum CLI Version |
|---------|-------------------|
| TaskBudget, ForkSession, DeleteSession, Errors on ResultMessage | >= 2.1.85 |
| GetContextUsage, control_cancel_request handling | >= 2.1.87 |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes