### PR TITLE
feat: add 'auto' permission mode (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `CLAUDE_AGENT_SDK_INITIALIZE_TIMEOUT` environment variable support for configuring the initialization timeout, with fallback to `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` for backwards compatibility. Port of Python SDK [anthropics/claude-agent-sdk-python#743](https://github.com/anthropics/claude-agent-sdk-python/pull/743). ([#92](https://github.com/Flohs/claude-agent-sdk-go/issues/92))
+- `PermissionModeAuto` constant for the `auto` permission mode supported by CLI 2.1.90+. Port of Python SDK [anthropics/claude-agent-sdk-python#785](https://github.com/anthropics/claude-agent-sdk-python/pull/785). ([#90](https://github.com/Flohs/claude-agent-sdk-go/issues/90))
 
 ### Changed
 

--- a/options.go
+++ b/options.go
@@ -9,6 +9,7 @@ const (
 	PermissionModePlan              PermissionMode = "plan"
 	PermissionModeBypassPermissions PermissionMode = "bypassPermissions"
 	PermissionModeDontAsk           PermissionMode = "dontAsk"
+	PermissionModeAuto              PermissionMode = "auto"
 )
 
 // SdkBeta represents beta feature flags.


### PR DESCRIPTION
Closes #90

## Summary

- Add `PermissionModeAuto` constant (`"auto"`) to the `PermissionMode` type in `options.go`
- Port of Python SDK [anthropics/claude-agent-sdk-python#785](https://github.com/anthropics/claude-agent-sdk-python/pull/785), for the `auto` permission mode supported by CLI 2.1.90+

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes