### PR TITLE
feat(mcp): forward maxResultSizeChars via _meta (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `CLAUDE_AGENT_SDK_INITIALIZE_TIMEOUT` environment variable support for configuring the initialization timeout, with fallback to `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT` for backwards compatibility. Port of Python SDK [anthropics/claude-agent-sdk-python#743](https://github.com/anthropics/claude-agent-sdk-python/pull/743). ([#92](https://github.com/Flohs/claude-agent-sdk-go/issues/92))
 - `PermissionModeAuto` constant for the `auto` permission mode supported by CLI 2.1.90+. Port of Python SDK [anthropics/claude-agent-sdk-python#785](https://github.com/anthropics/claude-agent-sdk-python/pull/785). ([#90](https://github.com/Flohs/claude-agent-sdk-go/issues/90))
+- `SdkMcpToolAnnotations` type and `Annotations` field on `SdkMcpTool` for configuring MCP tool annotations including `MaxResultSizeChars`, which is forwarded via `_meta["anthropic/maxResultSizeChars"]` to bypass Zod annotation stripping in the CLI. Port of Python SDK [anthropics/claude-agent-sdk-python#756](https://github.com/anthropics/claude-agent-sdk-python/pull/756). ([#91](https://github.com/Flohs/claude-agent-sdk-go/issues/91))
 
 ### Changed
 

--- a/mcp.go
+++ b/mcp.go
@@ -146,11 +146,20 @@ type McpStatusResponse struct {
 // SdkMcpToolHandler is the handler function for an SDK MCP tool.
 type SdkMcpToolHandler func(ctx context.Context, arguments map[string]any) (map[string]any, error)
 
+// SdkMcpToolAnnotations contains tool annotations for SDK MCP tools.
+type SdkMcpToolAnnotations struct {
+	ReadOnly           *bool `json:"readOnly,omitempty"`
+	Destructive        *bool `json:"destructive,omitempty"`
+	OpenWorld          *bool `json:"openWorld,omitempty"`
+	MaxResultSizeChars *int  `json:"maxResultSizeChars,omitempty"`
+}
+
 // SdkMcpTool defines an SDK MCP tool.
 type SdkMcpTool struct {
 	Name        string
 	Description string
 	InputSchema map[string]any
+	Annotations *SdkMcpToolAnnotations
 	Handler     SdkMcpToolHandler
 }
 
@@ -256,6 +265,26 @@ func (r *sdkMcpRouter) handleRequest(ctx context.Context, serverName string, mes
 				"name":        tool.Name,
 				"description": tool.Description,
 				"inputSchema": tool.InputSchema,
+			}
+			if tool.Annotations != nil {
+				annotations := map[string]any{}
+				if tool.Annotations.ReadOnly != nil {
+					annotations["readOnly"] = *tool.Annotations.ReadOnly
+				}
+				if tool.Annotations.Destructive != nil {
+					annotations["destructive"] = *tool.Annotations.Destructive
+				}
+				if tool.Annotations.OpenWorld != nil {
+					annotations["openWorld"] = *tool.Annotations.OpenWorld
+				}
+				if len(annotations) > 0 {
+					toolData["annotations"] = annotations
+				}
+				if tool.Annotations.MaxResultSizeChars != nil {
+					toolData["_meta"] = map[string]any{
+						"anthropic/maxResultSizeChars": *tool.Annotations.MaxResultSizeChars,
+					}
+				}
 			}
 			toolsList[i] = toolData
 		}


### PR DESCRIPTION
Closes #91

## Summary

- Added `SdkMcpToolAnnotations` struct with `ReadOnly`, `Destructive`, `OpenWorld`, and `MaxResultSizeChars` fields
- Added `Annotations` field to `SdkMcpTool`
- In the `tools/list` MCP handler, standard annotations are forwarded under `annotations` and `MaxResultSizeChars` is forwarded via `_meta["anthropic/maxResultSizeChars"]` to bypass Zod annotation stripping in the CLI
- Port of Python SDK [anthropics/claude-agent-sdk-python#756](https://github.com/anthropics/claude-agent-sdk-python/pull/756)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes
- [ ] Manual: create an `SdkMcpTool` with `Annotations` containing `MaxResultSizeChars` and verify the `tools/list` response includes `_meta` with the correct key