### PR TITLE
fix: map ThinkingConfigAdaptive/Disabled to --thinking flag instead of --max-thinking-tokens (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `ThinkingConfigAdaptive` and `ThinkingConfigDisabled` now correctly map to `--thinking adaptive` / `--thinking disabled` CLI flags instead of incorrectly using `--max-thinking-tokens`. `ThinkingConfigEnabled` and the deprecated `MaxThinkingTokens` field continue to use `--max-thinking-tokens`. ([#99](https://github.com/Flohs/claude-agent-sdk-go/issues/99))
+
 ## [1.5.0] - 2026-04-08
 
 ### Added

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -483,23 +483,17 @@ func (t *SubprocessTransport) buildCommand() []string {
 	}
 
 	// Thinking config
-	resolvedMaxThinkingTokens := opts.MaxThinkingTokens
 	if opts.Thinking != nil {
 		switch tc := opts.Thinking.(type) {
 		case ThinkingConfigAdaptive:
-			if resolvedMaxThinkingTokens == nil {
-				v := 32000
-				resolvedMaxThinkingTokens = &v
-			}
-		case ThinkingConfigEnabled:
-			resolvedMaxThinkingTokens = &tc.BudgetTokens
+			cmd = append(cmd, "--thinking", "adaptive")
 		case ThinkingConfigDisabled:
-			v := 0
-			resolvedMaxThinkingTokens = &v
+			cmd = append(cmd, "--thinking", "disabled")
+		case ThinkingConfigEnabled:
+			cmd = append(cmd, "--max-thinking-tokens", strconv.Itoa(tc.BudgetTokens))
 		}
-	}
-	if resolvedMaxThinkingTokens != nil {
-		cmd = append(cmd, "--max-thinking-tokens", strconv.Itoa(*resolvedMaxThinkingTokens))
+	} else if opts.MaxThinkingTokens != nil {
+		cmd = append(cmd, "--max-thinking-tokens", strconv.Itoa(*opts.MaxThinkingTokens))
 	}
 
 	if opts.Effort != "" {

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -97,7 +97,7 @@ func TestBuildCommand_Tools(t *testing.T) {
 }
 
 func TestBuildCommand_ThinkingConfig(t *testing.T) {
-	t.Run("adaptive", func(t *testing.T) {
+	t.Run("adaptive uses --thinking flag", func(t *testing.T) {
 		transport := &SubprocessTransport{
 			cliPath: "claude",
 			options: &Options{
@@ -105,10 +105,23 @@ func TestBuildCommand_ThinkingConfig(t *testing.T) {
 			},
 		}
 		cmd := transport.buildCommand()
-		assertContains(t, cmd, "--max-thinking-tokens", "32000")
+		assertContains(t, cmd, "--thinking", "adaptive")
+		assertNotContainsFlag(t, cmd, "--max-thinking-tokens")
 	})
 
-	t.Run("enabled", func(t *testing.T) {
+	t.Run("disabled uses --thinking flag", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Thinking: ThinkingConfigDisabled{},
+			},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--thinking", "disabled")
+		assertNotContainsFlag(t, cmd, "--max-thinking-tokens")
+	})
+
+	t.Run("enabled uses --max-thinking-tokens", func(t *testing.T) {
 		transport := &SubprocessTransport{
 			cliPath: "claude",
 			options: &Options{
@@ -117,17 +130,34 @@ func TestBuildCommand_ThinkingConfig(t *testing.T) {
 		}
 		cmd := transport.buildCommand()
 		assertContains(t, cmd, "--max-thinking-tokens", "16000")
+		assertNotContainsFlag(t, cmd, "--thinking")
 	})
 
-	t.Run("disabled", func(t *testing.T) {
+	t.Run("deprecated MaxThinkingTokens fallback", func(t *testing.T) {
+		v := 8000
 		transport := &SubprocessTransport{
 			cliPath: "claude",
 			options: &Options{
-				Thinking: ThinkingConfigDisabled{},
+				MaxThinkingTokens: &v,
 			},
 		}
 		cmd := transport.buildCommand()
-		assertContains(t, cmd, "--max-thinking-tokens", "0")
+		assertContains(t, cmd, "--max-thinking-tokens", "8000")
+		assertNotContainsFlag(t, cmd, "--thinking")
+	})
+
+	t.Run("Thinking takes precedence over MaxThinkingTokens", func(t *testing.T) {
+		v := 8000
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Thinking:          ThinkingConfigAdaptive{},
+				MaxThinkingTokens: &v,
+			},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--thinking", "adaptive")
+		assertNotContainsFlag(t, cmd, "--max-thinking-tokens")
 	})
 }
 
@@ -286,6 +316,16 @@ func assertContainsFlag(t *testing.T, cmd []string, flag string) {
 		}
 	}
 	t.Errorf("command %v does not contain %s", cmd, flag)
+}
+
+func assertNotContainsFlag(t *testing.T, cmd []string, flag string) {
+	t.Helper()
+	for _, arg := range cmd {
+		if arg == flag {
+			t.Errorf("command %v should not contain %s", cmd, flag)
+			return
+		}
+	}
 }
 
 func TestBuildCommand_SettingSources(t *testing.T) {


### PR DESCRIPTION
Closes #99

## Summary

- `ThinkingConfigAdaptive` now maps to `--thinking adaptive` instead of `--max-thinking-tokens 32000`
- `ThinkingConfigDisabled` now maps to `--thinking disabled` instead of `--max-thinking-tokens 0`
- `ThinkingConfigEnabled` continues to use `--max-thinking-tokens <budget>` (unchanged)
- Deprecated `MaxThinkingTokens` field still works as fallback when `Thinking` is nil
- `Thinking` takes precedence over `MaxThinkingTokens` when both are set

## Test plan

- [x] Unit tests updated to verify correct flag generation for all thinking config variants
- [x] New test cases for deprecated `MaxThinkingTokens` fallback and precedence behavior
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes