### PR TITLE
feat: add ExcludeDynamicSections to PresetPrompt for cross-user prompt caching (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ExcludeDynamicSections` field on `PresetPrompt` for cross-user prompt caching. When set, the SDK sends `excludeDynamicSections` in the initialize request to tell Claude Code to omit user-specific dynamic sections from the system prompt. ([#98](https://github.com/Flohs/claude-agent-sdk-go/issues/98))
+
 ### Fixed
 
 - `ThinkingConfigAdaptive` and `ThinkingConfigDisabled` now correctly map to `--thinking adaptive` / `--thinking disabled` CLI flags instead of incorrectly using `--max-thinking-tokens`. `ThinkingConfigEnabled` and the deprecated `MaxThinkingTokens` field continue to use `--max-thinking-tokens`. ([#99](https://github.com/Flohs/claude-agent-sdk-go/issues/99))

--- a/claude.go
+++ b/claude.go
@@ -92,13 +92,20 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 		// Extract SDK MCP servers
 		sdkServers := extractSdkMcpServers(configuredOpts.McpServers)
 
+		// Extract excludeDynamicSections from PresetPrompt if set
+		var excludeDynamic bool
+		if pp, ok := configuredOpts.SystemPrompt.(PresetPrompt); ok {
+			excludeDynamic = pp.ExcludeDynamicSections
+		}
+
 		// Create query handler
 		q := newQuery(queryConfig{
-			transport:  transport,
-			canUseTool: configuredOpts.CanUseTool,
-			hooks:      configuredOpts.Hooks,
-			mcpServers: sdkServers,
-			agents:     configuredOpts.Agents,
+			transport:              transport,
+			canUseTool:             configuredOpts.CanUseTool,
+			hooks:                  configuredOpts.Hooks,
+			mcpServers:             sdkServers,
+			agents:                 configuredOpts.Agents,
+			excludeDynamicSections: excludeDynamic,
 		})
 
 		q.start()

--- a/client.go
+++ b/client.go
@@ -57,13 +57,20 @@ func (c *Client) Connect(ctx context.Context, prompt ...string) error {
 	// Extract SDK MCP servers
 	sdkServers := extractSdkMcpServers(configuredOpts.McpServers)
 
+	// Extract excludeDynamicSections from PresetPrompt if set
+	var excludeDynamic bool
+	if pp, ok := configuredOpts.SystemPrompt.(PresetPrompt); ok {
+		excludeDynamic = pp.ExcludeDynamicSections
+	}
+
 	// Create query handler
 	c.q = newQuery(queryConfig{
-		transport:  transport,
-		canUseTool: configuredOpts.CanUseTool,
-		hooks:      configuredOpts.Hooks,
-		mcpServers: sdkServers,
-		agents:     configuredOpts.Agents,
+		transport:              transport,
+		canUseTool:             configuredOpts.CanUseTool,
+		hooks:                  configuredOpts.Hooks,
+		mcpServers:             sdkServers,
+		agents:                 configuredOpts.Agents,
+		excludeDynamicSections: excludeDynamic,
 	})
 
 	c.q.start()

--- a/options.go
+++ b/options.go
@@ -50,8 +50,9 @@ func (StringPrompt) systemPromptMarker() {}
 
 // PresetPrompt is a preset system prompt (e.g. "claude_code") with optional appended text.
 type PresetPrompt struct {
-	Preset string `json:"preset"` // e.g. "claude_code"
-	Append string `json:"append,omitempty"`
+	Preset                 string `json:"preset"` // e.g. "claude_code"
+	Append                 string `json:"append,omitempty"`
+	ExcludeDynamicSections bool   `json:"excludeDynamicSections,omitempty"`
 }
 
 func (PresetPrompt) systemPromptMarker() {}

--- a/query.go
+++ b/query.go
@@ -32,13 +32,14 @@ type query struct {
 	messageCh chan map[string]any
 
 	// State
-	initTimeout        float64
-	initialized        bool
-	closed             bool
-	initializationResult map[string]any
-	firstResultCh      chan struct{}
-	firstResultOnce    sync.Once
-	streamCloseTimeout float64
+	initTimeout            float64
+	initialized            bool
+	closed                 bool
+	initializationResult   map[string]any
+	firstResultCh          chan struct{}
+	firstResultOnce        sync.Once
+	streamCloseTimeout     float64
+	excludeDynamicSections bool
 
 	ctx       context.Context
 	cancelFn  context.CancelFunc
@@ -52,12 +53,13 @@ type hookMatcherInternal struct {
 }
 
 type queryConfig struct {
-	transport      Transport
-	canUseTool     CanUseToolFunc
-	hooks          map[HookEvent][]HookMatcher
-	mcpServers     map[string]*McpSdkServerConfig
-	initTimeout    float64
-	agents         map[string]AgentDefinition
+	transport              Transport
+	canUseTool             CanUseToolFunc
+	hooks                  map[HookEvent][]HookMatcher
+	mcpServers             map[string]*McpSdkServerConfig
+	initTimeout            float64
+	agents                 map[string]AgentDefinition
+	excludeDynamicSections bool
 }
 
 func newQuery(cfg queryConfig) *query {
@@ -81,17 +83,18 @@ func newQuery(cfg queryConfig) *query {
 	}
 
 	q := &query{
-		transport:      cfg.transport,
-		canUseTool:     cfg.canUseTool,
-		hookCallbacks:  make(map[string]HookCallback),
-		pendingEvents:  make(map[string]chan struct{}),
-		pendingResults: make(map[string]any),
-		messageCh:      make(chan map[string]any, 100),
-		initTimeout:    initTimeout,
-		firstResultCh:  make(chan struct{}),
-		streamCloseTimeout: streamCloseTimeoutMs / 1000.0,
-		ctx:            ctx,
-		cancelFn:       cancel,
+		transport:              cfg.transport,
+		canUseTool:             cfg.canUseTool,
+		hookCallbacks:          make(map[string]HookCallback),
+		pendingEvents:          make(map[string]chan struct{}),
+		pendingResults:         make(map[string]any),
+		messageCh:              make(chan map[string]any, 100),
+		initTimeout:            initTimeout,
+		firstResultCh:          make(chan struct{}),
+		streamCloseTimeout:     streamCloseTimeoutMs / 1000.0,
+		excludeDynamicSections: cfg.excludeDynamicSections,
+		ctx:                    ctx,
+		cancelFn:               cancel,
 	}
 
 	// Convert hooks
@@ -407,6 +410,10 @@ func (q *query) initialize() (map[string]any, error) {
 	request := map[string]any{
 		"subtype": "initialize",
 		"hooks":   hooksConfig,
+	}
+
+	if q.excludeDynamicSections {
+		request["excludeDynamicSections"] = true
 	}
 
 	if q.agents != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -2,6 +2,8 @@ package claude
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -234,4 +236,137 @@ func TestStreamInput_UsesWaitForResultAndEndInput(t *testing.T) {
 	if len(mt.written) == 0 {
 		t.Fatal("expected at least one message to be written")
 	}
+}
+
+// autoRespondTransport extends mockTransport to automatically respond to control requests.
+// It overrides ReadMessages to respect context cancellation, so query.close() doesn't deadlock.
+type autoRespondTransport struct {
+	mockTransport
+}
+
+func newAutoRespondTransport() *autoRespondTransport {
+	return &autoRespondTransport{
+		mockTransport: mockTransport{
+			messages: make(chan map[string]any, 100),
+		},
+	}
+}
+
+func (a *autoRespondTransport) Write(data string) error {
+	a.mu.Lock()
+	a.written = append(a.written, data)
+	a.mu.Unlock()
+
+	// Auto-respond to control requests
+	var msg map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(data)), &msg); err == nil {
+		if msg["type"] == "control_request" {
+			reqID, _ := msg["request_id"].(string)
+			go func() {
+				a.messages <- map[string]any{
+					"type": "control_response",
+					"response": map[string]any{
+						"subtype":    "success",
+						"request_id": reqID,
+						"response":   map[string]any{},
+					},
+				}
+			}()
+		}
+	}
+	return nil
+}
+
+func (a *autoRespondTransport) ReadMessages(ctx context.Context) <-chan map[string]any {
+	out := make(chan map[string]any, 100)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case msg, ok := <-a.messages:
+				if !ok {
+					return
+				}
+				out <- msg
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func TestInitialize_ExcludeDynamicSections(t *testing.T) {
+	t.Run("sends excludeDynamicSections when true", func(t *testing.T) {
+		mt := newAutoRespondTransport()
+		q := newQuery(queryConfig{
+			transport:              mt,
+			excludeDynamicSections: true,
+		})
+
+		q.start()
+		_, err := q.initialize()
+		if err != nil {
+			t.Fatalf("initialize failed: %v", err)
+		}
+
+		// Copy written data before close (close acquires mu)
+		mt.mu.Lock()
+		written := make([]string, len(mt.written))
+		copy(written, mt.written)
+		mt.mu.Unlock()
+
+		_ = q.close()
+
+		found := false
+		for _, w := range written {
+			var msg map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(w)), &msg); err != nil {
+				continue
+			}
+			req, _ := msg["request"].(map[string]any)
+			if req != nil && req["subtype"] == "initialize" {
+				if val, ok := req["excludeDynamicSections"]; ok && val == true {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Error("initialize request should contain excludeDynamicSections: true")
+		}
+	})
+
+	t.Run("omits excludeDynamicSections when false", func(t *testing.T) {
+		mt := newAutoRespondTransport()
+		q := newQuery(queryConfig{
+			transport:              mt,
+			excludeDynamicSections: false,
+		})
+
+		q.start()
+		_, err := q.initialize()
+		if err != nil {
+			t.Fatalf("initialize failed: %v", err)
+		}
+
+		mt.mu.Lock()
+		written := make([]string, len(mt.written))
+		copy(written, mt.written)
+		mt.mu.Unlock()
+
+		_ = q.close()
+
+		for _, w := range written {
+			var msg map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(w)), &msg); err != nil {
+				continue
+			}
+			req, _ := msg["request"].(map[string]any)
+			if req != nil && req["subtype"] == "initialize" {
+				if _, ok := req["excludeDynamicSections"]; ok {
+					t.Error("initialize request should not contain excludeDynamicSections when false")
+				}
+			}
+		}
+	})
 }


### PR DESCRIPTION
Closes #98

## Summary

- Add `ExcludeDynamicSections` bool field to `PresetPrompt` struct
- Thread the value through `queryConfig` to the initialize control request as `excludeDynamicSections`
- Both `Client.Connect()` and `Query()` extract the field from `PresetPrompt` and pass it to the query layer
- Field is omitted from the request when `false` (default)

## Test plan

- [x] New `TestInitialize_ExcludeDynamicSections` verifying the field is sent when true and omitted when false
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes