### PR TITLE
feat: DeleteSession removes sibling subagent transcript directory (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `ExcludeDynamicSections` field on `PresetPrompt` for cross-user prompt caching. When set, the SDK sends `excludeDynamicSections` in the initialize request to tell Claude Code to omit user-specific dynamic sections from the system prompt. ([#98](https://github.com/Flohs/claude-agent-sdk-go/issues/98))
 
+### Changed
+
+- `DeleteSession` now also removes the sibling `{session_id}/` directory (where subagent transcripts live) on a best-effort basis, matching the Python SDK and TypeScript SDK. Failures removing the sibling directory are swallowed so the primary `.jsonl` delete still counts. Port of Python SDK [anthropics/claude-agent-sdk-python#805](https://github.com/anthropics/claude-agent-sdk-python/pull/805). ([#105](https://github.com/Flohs/claude-agent-sdk-go/issues/105))
+
 ### Fixed
 
 - `ThinkingConfigAdaptive` and `ThinkingConfigDisabled` now correctly map to `--thinking adaptive` / `--thinking disabled` CLI flags instead of incorrectly using `--max-thinking-tokens`. `ThinkingConfigEnabled` and the deprecated `MaxThinkingTokens` field continue to use `--max-thinking-tokens`. ([#99](https://github.com/Flohs/claude-agent-sdk-go/issues/99))

--- a/sessions.go
+++ b/sessions.go
@@ -161,7 +161,14 @@ func RenameSession(sessionID string, title string, directory *string) error {
 	return appendJSONLEntry(filePath, entry)
 }
 
-// DeleteSession deletes a session's JSONL transcript file.
+// DeleteSession deletes a session's JSONL transcript file and any subagent
+// transcripts stored in the sibling {session_id}/ directory.
+//
+// The JSONL file is a hard delete — an error is returned if it cannot be
+// removed. The sibling directory (if any) is removed on a best-effort basis;
+// failures there are swallowed so the primary delete still counts as a
+// success. This mirrors the Python SDK's `shutil.rmtree(..., ignore_errors=True)`
+// behavior.
 func DeleteSession(sessionID string, directory ...string) error {
 	if !isValidUUID(sessionID) {
 		return fmt.Errorf("invalid session ID: %s", sessionID)
@@ -177,7 +184,16 @@ func DeleteSession(sessionID string, directory ...string) error {
 		return fmt.Errorf("session not found: %s", sessionID)
 	}
 
-	return os.Remove(filePath)
+	if err := os.Remove(filePath); err != nil {
+		return err
+	}
+
+	// Subagent transcripts live in a sibling {session_id}/ dir alongside the
+	// .jsonl file. Often absent; remove best-effort.
+	siblingDir := filepath.Join(filepath.Dir(filePath), sessionID)
+	_ = os.RemoveAll(siblingDir)
+
+	return nil
 }
 
 // ForkSession creates a copy of a session's transcript file with a new session ID.

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -2433,3 +2433,54 @@ func TestExtractCreatedAtFromHead_NoTimestamp(t *testing.T) {
 		t.Errorf("expected nil, got %d", *result)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DeleteSession
+// ---------------------------------------------------------------------------
+
+func TestDeleteSession_RemovesJSONLAndSubagentDir(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/delete-cascade")
+	filePath := writeSessionFile(t, projDir, testUUID1, "{}\n")
+
+	subagentDir := filepath.Join(projDir, testUUID1)
+	if err := os.MkdirAll(subagentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subagentFile := filepath.Join(subagentDir, testUUID2+".jsonl")
+	if err := os.WriteFile(subagentFile, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteSession(testUUID1, "/test/delete-cascade"); err != nil {
+		t.Fatalf("DeleteSession returned error: %v", err)
+	}
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Errorf("expected .jsonl to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(subagentDir); !os.IsNotExist(err) {
+		t.Errorf("expected subagent dir to be removed, stat err=%v", err)
+	}
+}
+
+func TestDeleteSession_NoSubagentDirNoError(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/delete-no-subagent")
+	filePath := writeSessionFile(t, projDir, testUUID1, "{}\n")
+
+	if err := DeleteSession(testUUID1, "/test/delete-no-subagent"); err != nil {
+		t.Fatalf("DeleteSession returned error: %v", err)
+	}
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Errorf("expected .jsonl to be removed, stat err=%v", err)
+	}
+}
+
+func TestDeleteSession_MissingSessionStillErrors(t *testing.T) {
+	// Preserves existing "session not found" behavior when the .jsonl is
+	// absent. Ensures the cascade logic didn't change the primary contract.
+	_ = setupTestProjectDir(t, "/test/delete-missing")
+
+	err := DeleteSession(testUUID1, "/test/delete-missing")
+	if err == nil {
+		t.Fatal("expected error for missing session, got nil")
+	}
+}


### PR DESCRIPTION
Closes #105

## Summary

- `DeleteSession` now also removes the sibling `{session_id}/` directory (where subagent transcripts live) on a best-effort basis.
- Matches the Python SDK (anthropics/claude-agent-sdk-python#805) and existing TypeScript SDK behavior. Previously subagent transcripts were orphaned after a session delete.
- The primary `.jsonl` deletion is unchanged — still hard-errors on failure. Only the sibling-directory removal is best-effort (equivalent to Python's `shutil.rmtree(..., ignore_errors=True)`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] Unit tests cover: (a) cascade removes both `.jsonl` + sibling dir, (b) no sibling dir is not an error, (c) missing session still returns the existing `"session not found"` error (primary contract preserved).