### PR TITLE
feat: add Options.Title for session title (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Options.Title` field that sets the session title and skips auto-generation, forwarded as `--title` to the CLI. Port of TypeScript SDK v0.2.113. ([#111](https://github.com/Flohs/claude-agent-sdk-go/issues/111))
 - `ExcludeDynamicSections` field on `PresetPrompt` for cross-user prompt caching. When set, the SDK sends `excludeDynamicSections` in the initialize request to tell Claude Code to omit user-specific dynamic sections from the system prompt. ([#98](https://github.com/Flohs/claude-agent-sdk-go/issues/98))
 
 ### Changed

--- a/options.go
+++ b/options.go
@@ -158,6 +158,8 @@ type Options struct {
 	Resume string
 	// SessionID specifies a custom session ID for the conversation.
 	SessionID string
+	// Title sets the session title and skips auto-generation.
+	Title string
 	// MaxTurns limits the number of conversation turns.
 	MaxTurns *int
 	// MaxBudgetUSD limits the total cost.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -419,6 +419,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--session-id", opts.SessionID)
 	}
 
+	if opts.Title != "" {
+		cmd = append(cmd, "--title", opts.Title)
+	}
+
 	// Settings and sandbox
 	settingsValue := t.buildSettingsValue()
 	if settingsValue != "" {

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -328,6 +328,26 @@ func assertNotContainsFlag(t *testing.T, cmd []string, flag string) {
 	}
 }
 
+func TestBuildCommand_Title(t *testing.T) {
+	t.Run("empty title omits flag", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{},
+		}
+		cmd := transport.buildCommand()
+		assertNotContainsFlag(t, cmd, "--title")
+	})
+
+	t.Run("title sets flag", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{Title: "My Session"},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--title", "My Session")
+	})
+}
+
 func TestBuildCommand_SettingSources(t *testing.T) {
 	t.Run("nil setting sources omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{


### PR DESCRIPTION
Closes #111

## Summary
- Adds `Options.Title` field for setting the session title up front and skipping the CLI's auto-generation
- Wires it through to the CLI as `--title <value>`
- Port of TypeScript SDK v0.2.113

## Test plan
- [x] Unit test `TestBuildCommand_Title` verifies flag emission
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` passes