### PR TITLE
feat: add Options.ManagedSettings (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Options.ManagedSettings` field for passing policy-tier settings to the spawned CLI in-memory, forwarded as `--managed-settings`. Honored below IT-controlled managed sources. Port of TypeScript SDK v0.2.118. ([#112](https://github.com/Flohs/claude-agent-sdk-go/issues/112))
 - `Options.Title` field that sets the session title and skips auto-generation, forwarded as `--title` to the CLI. Port of TypeScript SDK v0.2.113. ([#111](https://github.com/Flohs/claude-agent-sdk-go/issues/111))
 - `ExcludeDynamicSections` field on `PresetPrompt` for cross-user prompt caching. When set, the SDK sends `excludeDynamicSections` in the initialize request to tell Claude Code to omit user-specific dynamic sections from the system prompt. ([#98](https://github.com/Flohs/claude-agent-sdk-go/issues/98))
 

--- a/options.go
+++ b/options.go
@@ -183,6 +183,9 @@ type Options struct {
 	CLIPath string
 	// Settings is a JSON string or file path for settings.
 	Settings string
+	// ManagedSettings is a JSON string of policy-tier settings forwarded to the
+	// spawned CLI in-memory. Honored below IT-controlled managed sources.
+	ManagedSettings string
 	// AddDirs adds additional directories.
 	AddDirs []string
 	// Env sets additional environment variables for the CLI process.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -429,6 +429,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--settings", settingsValue)
 	}
 
+	if opts.ManagedSettings != "" {
+		cmd = append(cmd, "--managed-settings", opts.ManagedSettings)
+	}
+
 	for _, dir := range opts.AddDirs {
 		cmd = append(cmd, "--add-dir", dir)
 	}

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -328,6 +328,26 @@ func assertNotContainsFlag(t *testing.T, cmd []string, flag string) {
 	}
 }
 
+func TestBuildCommand_ManagedSettings(t *testing.T) {
+	t.Run("empty omits flag", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{},
+		}
+		cmd := transport.buildCommand()
+		assertNotContainsFlag(t, cmd, "--managed-settings")
+	})
+
+	t.Run("sets flag", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{ManagedSettings: `{"policy":true}`},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--managed-settings", `{"policy":true}`)
+	})
+}
+
 func TestBuildCommand_Title(t *testing.T) {
 	t.Run("empty title omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{


### PR DESCRIPTION
Closes #112

## Summary
- Adds `Options.ManagedSettings` for embedders to pass policy-tier settings to the CLI in-memory
- Wired as `--managed-settings <json>`
- Port of TypeScript SDK v0.2.118

## Test plan
- [x] Unit test verifies flag emission
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` clean