### PR TITLE
feat: add top-level Options.Skills (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Top-level `Options.Skills` field for enabling skills on the main session without manually configuring `AllowedTools` and `SettingSources`. Accepts `"all"` for every discovered skill or `[]string` of named skills. When set, the SDK auto-injects `Skill` / `Skill(name)` entries into `AllowedTools` and defaults `SettingSources` to `[user, project]` if unset. Port of Python SDK v0.1.62. ([#113](https://github.com/Flohs/claude-agent-sdk-go/issues/113))
 - `Options.ManagedSettings` field for passing policy-tier settings to the spawned CLI in-memory, forwarded as `--managed-settings`. Honored below IT-controlled managed sources. Port of TypeScript SDK v0.2.118. ([#112](https://github.com/Flohs/claude-agent-sdk-go/issues/112))
 - `Options.Title` field that sets the session title and skips auto-generation, forwarded as `--title` to the CLI. Port of TypeScript SDK v0.2.113. ([#111](https://github.com/Flohs/claude-agent-sdk-go/issues/111))
 - `ExcludeDynamicSections` field on `PresetPrompt` for cross-user prompt caching. When set, the SDK sends `excludeDynamicSections` in the initialize request to tell Claude Code to omit user-specific dynamic sections from the system prompt. ([#98](https://github.com/Flohs/claude-agent-sdk-go/issues/98))

--- a/options.go
+++ b/options.go
@@ -209,6 +209,12 @@ type Options struct {
 	ForkSession bool
 	// Agents defines custom agent configurations.
 	Agents map[string]AgentDefinition
+	// Skills enables skills on the main session without manually configuring
+	// AllowedTools and SettingSources. Use []string for named skills,
+	// the string "all" for every discovered skill, or leave nil to disable.
+	// When set, the SDK automatically injects Skill tool entries into
+	// AllowedTools and defaults SettingSources to [user, project] if unset.
+	Skills any // []string | "all" | nil
 	// SettingSources specifies which setting sources to load.
 	SettingSources []SettingSource
 	// Sandbox configures bash command isolation.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -304,6 +304,55 @@ func (t *SubprocessTransport) EndInput() error {
 	return nil
 }
 
+// applySkillsDefaults computes the effective AllowedTools and SettingSources
+// when Options.Skills is set. When Skills is "all", it injects the bare Skill
+// tool; when it is a []string, it injects Skill(name) for each entry. In either
+// case SettingSources defaults to [user, project] if unset so the CLI
+// discovers installed skills without the caller having to wire both options
+// manually. Returns copies — the original options are not mutated.
+func applySkillsDefaults(opts *Options) ([]string, []SettingSource) {
+	allowed := append([]string(nil), opts.AllowedTools...)
+	settingSources := opts.SettingSources
+
+	if opts.Skills == nil {
+		return allowed, settingSources
+	}
+
+	injected := false
+	switch s := opts.Skills.(type) {
+	case string:
+		if s == "all" {
+			if !stringSliceContains(allowed, "Skill") {
+				allowed = append(allowed, "Skill")
+			}
+			injected = true
+		}
+	case []string:
+		for _, name := range s {
+			pattern := "Skill(" + name + ")"
+			if !stringSliceContains(allowed, pattern) {
+				allowed = append(allowed, pattern)
+			}
+		}
+		injected = len(s) > 0
+	}
+
+	if injected && settingSources == nil {
+		settingSources = []SettingSource{SettingSourceUser, SettingSourceProject}
+	}
+
+	return allowed, settingSources
+}
+
+func stringSliceContains(s []string, target string) bool {
+	for _, v := range s {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *SubprocessTransport) hasExtraArg(key string) bool {
 	if t.options.ExtraArgs == nil {
 		return false
@@ -363,8 +412,9 @@ func (t *SubprocessTransport) buildCommand() []string {
 		}
 	}
 
-	if len(opts.AllowedTools) > 0 {
-		cmd = append(cmd, "--allowedTools", strings.Join(opts.AllowedTools, ","))
+	effectiveAllowedTools, effectiveSettingSources := applySkillsDefaults(opts)
+	if len(effectiveAllowedTools) > 0 {
+		cmd = append(cmd, "--allowedTools", strings.Join(effectiveAllowedTools, ","))
 	}
 
 	if opts.MaxTurns != nil {
@@ -466,9 +516,9 @@ func (t *SubprocessTransport) buildCommand() []string {
 	}
 
 	// Setting sources
-	if opts.SettingSources != nil {
-		sources := make([]string, len(opts.SettingSources))
-		for i, s := range opts.SettingSources {
+	if effectiveSettingSources != nil {
+		sources := make([]string, len(effectiveSettingSources))
+		for i, s := range effectiveSettingSources {
 			sources[i] = string(s)
 		}
 		cmd = append(cmd, "--setting-sources", strings.Join(sources, ","))

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -328,6 +328,79 @@ func assertNotContainsFlag(t *testing.T, cmd []string, flag string) {
 	}
 }
 
+func TestBuildCommand_Skills(t *testing.T) {
+	t.Run("nil skills preserves user config", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				AllowedTools: []string{"Read"},
+			},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--allowedTools", "Read")
+		assertNotContainsFlag(t, cmd, "--setting-sources")
+	})
+
+	t.Run("skills all injects Skill tool and defaults setting sources", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{Skills: "all"},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--allowedTools", "Skill")
+		found := false
+		for i, a := range cmd {
+			if a == "--setting-sources" && i+1 < len(cmd) {
+				if !strings.Contains(cmd[i+1], "user") || !strings.Contains(cmd[i+1], "project") {
+					t.Errorf("expected user,project default, got %s", cmd[i+1])
+				}
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected --setting-sources to be defaulted when skills is set")
+		}
+	})
+
+	t.Run("skills list injects Skill(name) patterns", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{Skills: []string{"pdf-tools", "image-tools"}},
+		}
+		cmd := transport.buildCommand()
+		for i, a := range cmd {
+			if a == "--allowedTools" && i+1 < len(cmd) {
+				v := cmd[i+1]
+				if !strings.Contains(v, "Skill(pdf-tools)") || !strings.Contains(v, "Skill(image-tools)") {
+					t.Errorf("expected both Skill(name) patterns, got %s", v)
+				}
+				return
+			}
+		}
+		t.Error("--allowedTools not found")
+	})
+
+	t.Run("skills respects explicit setting sources", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Skills:         "all",
+				SettingSources: []SettingSource{SettingSourceLocal},
+			},
+		}
+		cmd := transport.buildCommand()
+		for i, a := range cmd {
+			if a == "--setting-sources" && i+1 < len(cmd) {
+				if cmd[i+1] != "local" {
+					t.Errorf("expected explicit setting-sources to be preserved, got %s", cmd[i+1])
+				}
+				return
+			}
+		}
+		t.Error("--setting-sources not found")
+	})
+}
+
 func TestBuildCommand_ManagedSettings(t *testing.T) {
 	t.Run("empty omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{


### PR DESCRIPTION
Closes #113

## Summary
- Adds `Options.Skills` top-level field (`[]string | \"all\" | nil`)
- Auto-injects `Skill` / `Skill(name)` entries into `AllowedTools`
- Defaults `SettingSources` to `[user, project]` when `Skills` is set and `SettingSources` is nil
- Explicit `SettingSources` / `AllowedTools` from the user are preserved
- Port of Python SDK v0.1.62 (`_apply_skills_defaults`)

## Test plan
- [x] 4 unit tests (`TestBuildCommand_Skills`) covering nil, "all", list, explicit-override cases
- [x] Full suite `go test -race ./...` clean