### PR TITLE
feat: add Options.IncludeHookEvents (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Options.IncludeHookEvents` field that enables hook lifecycle system messages (`hook_started`, `hook_progress`, `hook_response`) for all hook event types, forwarded as `--include-hook-events` to the CLI. Port of TypeScript SDK v0.2.89. ([#114](https://github.com/Flohs/claude-agent-sdk-go/issues/114))
 - Top-level `Options.Skills` field for enabling skills on the main session without manually configuring `AllowedTools` and `SettingSources`. Accepts `"all"` for every discovered skill or `[]string` of named skills. When set, the SDK auto-injects `Skill` / `Skill(name)` entries into `AllowedTools` and defaults `SettingSources` to `[user, project]` if unset. Port of Python SDK v0.1.62. ([#113](https://github.com/Flohs/claude-agent-sdk-go/issues/113))
 - `Options.ManagedSettings` field for passing policy-tier settings to the spawned CLI in-memory, forwarded as `--managed-settings`. Honored below IT-controlled managed sources. Port of TypeScript SDK v0.2.118. ([#112](https://github.com/Flohs/claude-agent-sdk-go/issues/112))
 - `Options.Title` field that sets the session title and skips auto-generation, forwarded as `--title` to the CLI. Port of TypeScript SDK v0.2.113. ([#111](https://github.com/Flohs/claude-agent-sdk-go/issues/111))

--- a/options.go
+++ b/options.go
@@ -205,6 +205,9 @@ type Options struct {
 	User string
 	// IncludePartialMessages enables partial message streaming.
 	IncludePartialMessages bool
+	// IncludeHookEvents enables hook lifecycle system messages
+	// (hook_started, hook_progress, hook_response) for all hook event types.
+	IncludeHookEvents bool
 	// ForkSession forks resumed sessions to a new session ID.
 	ForkSession bool
 	// Agents defines custom agent configurations.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -511,6 +511,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--include-partial-messages")
 	}
 
+	if opts.IncludeHookEvents {
+		cmd = append(cmd, "--include-hook-events")
+	}
+
 	if opts.ForkSession {
 		cmd = append(cmd, "--fork-session")
 	}

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -401,6 +401,19 @@ func TestBuildCommand_Skills(t *testing.T) {
 	})
 }
 
+func TestBuildCommand_IncludeHookEvents(t *testing.T) {
+	t.Run("false omits flag", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{}}
+		cmd := transport.buildCommand()
+		assertNotContainsFlag(t, cmd, "--include-hook-events")
+	})
+	t.Run("true sets flag", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{IncludeHookEvents: true}}
+		cmd := transport.buildCommand()
+		assertContainsFlag(t, cmd, "--include-hook-events")
+	})
+}
+
 func TestBuildCommand_ManagedSettings(t *testing.T) {
 	t.Run("empty omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{


### PR DESCRIPTION
Closes #114

## Summary
- Adds `Options.IncludeHookEvents bool` → `--include-hook-events`
- Port of TypeScript SDK v0.2.89

## Test plan
- [x] Unit test covers both flag states
- [x] `go test -race ./...` clean