### PR TITLE
feat: add Options.AgentProgressSummaries (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Options.AgentProgressSummaries` field that enables periodic AI-generated progress summaries on `task_progress` messages, forwarded as `--agent-progress-summaries`. Also adds a typed `Summary` field on `TaskProgressMessage`. Port of TypeScript SDK v0.2.72. ([#115](https://github.com/Flohs/claude-agent-sdk-go/issues/115))
 - `Options.IncludeHookEvents` field that enables hook lifecycle system messages (`hook_started`, `hook_progress`, `hook_response`) for all hook event types, forwarded as `--include-hook-events` to the CLI. Port of TypeScript SDK v0.2.89. ([#114](https://github.com/Flohs/claude-agent-sdk-go/issues/114))
 - Top-level `Options.Skills` field for enabling skills on the main session without manually configuring `AllowedTools` and `SettingSources`. Accepts `"all"` for every discovered skill or `[]string` of named skills. When set, the SDK auto-injects `Skill` / `Skill(name)` entries into `AllowedTools` and defaults `SettingSources` to `[user, project]` if unset. Port of Python SDK v0.1.62. ([#113](https://github.com/Flohs/claude-agent-sdk-go/issues/113))
 - `Options.ManagedSettings` field for passing policy-tier settings to the spawned CLI in-memory, forwarded as `--managed-settings`. Honored below IT-controlled managed sources. Port of TypeScript SDK v0.2.118. ([#112](https://github.com/Flohs/claude-agent-sdk-go/issues/112))

--- a/message_parser.go
+++ b/message_parser.go
@@ -152,6 +152,7 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 			SessionID:     stringField(data, "session_id"),
 			ToolUseID:     stringField(data, "tool_use_id"),
 			LastToolName:  stringField(data, "last_tool_name"),
+			Summary:       stringField(data, "summary"),
 		}, nil
 
 	case "task_notification":

--- a/options.go
+++ b/options.go
@@ -208,6 +208,10 @@ type Options struct {
 	// IncludeHookEvents enables hook lifecycle system messages
 	// (hook_started, hook_progress, hook_response) for all hook event types.
 	IncludeHookEvents bool
+	// AgentProgressSummaries enables periodic AI-generated progress summaries
+	// on task_progress messages. When set, task progress messages carry a
+	// Summary field describing the subagent's current activity.
+	AgentProgressSummaries bool
 	// ForkSession forks resumed sessions to a new session ID.
 	ForkSession bool
 	// Agents defines custom agent configurations.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -515,6 +515,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--include-hook-events")
 	}
 
+	if opts.AgentProgressSummaries {
+		cmd = append(cmd, "--agent-progress-summaries")
+	}
+
 	if opts.ForkSession {
 		cmd = append(cmd, "--fork-session")
 	}

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -401,6 +401,19 @@ func TestBuildCommand_Skills(t *testing.T) {
 	})
 }
 
+func TestBuildCommand_AgentProgressSummaries(t *testing.T) {
+	t.Run("false omits flag", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{}}
+		cmd := transport.buildCommand()
+		assertNotContainsFlag(t, cmd, "--agent-progress-summaries")
+	})
+	t.Run("true sets flag", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{AgentProgressSummaries: true}}
+		cmd := transport.buildCommand()
+		assertContainsFlag(t, cmd, "--agent-progress-summaries")
+	})
+}
+
 func TestBuildCommand_IncludeHookEvents(t *testing.T) {
 	t.Run("false omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{cliPath: "claude", options: &Options{}}

--- a/types.go
+++ b/types.go
@@ -172,6 +172,9 @@ type TaskProgressMessage struct {
 	SessionID    string    `json:"session_id"`
 	ToolUseID    string    `json:"tool_use_id,omitempty"`
 	LastToolName string    `json:"last_tool_name,omitempty"`
+	// Summary is an AI-generated progress summary when AgentProgressSummaries
+	// is enabled in Options.
+	Summary string `json:"summary,omitempty"`
 }
 
 // TaskNotificationMessage is emitted when a task completes, fails, or is stopped.


### PR DESCRIPTION
Closes #115

## Summary
- Adds `Options.AgentProgressSummaries bool` → `--agent-progress-summaries`
- Adds typed `Summary` field on `TaskProgressMessage`
- Parser populates the field
- Port of TypeScript SDK v0.2.72

## Test plan
- [x] Unit test for flag
- [x] `go test -race ./...` clean