### PR TITLE
feat: add ThinkingDisplay on ThinkingConfig (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Display` field on `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`, plus `ThinkingDisplay` type with `ThinkingDisplaySummarized`/`ThinkingDisplayOmitted` constants. Forwarded as `--thinking-display` to let callers override Opus 4.7's default `omitted` thinking text. Port of Python SDK v0.1.65. ([#116](https://github.com/Flohs/claude-agent-sdk-go/issues/116))
 - `Options.AgentProgressSummaries` field that enables periodic AI-generated progress summaries on `task_progress` messages, forwarded as `--agent-progress-summaries`. Also adds a typed `Summary` field on `TaskProgressMessage`. Port of TypeScript SDK v0.2.72. ([#115](https://github.com/Flohs/claude-agent-sdk-go/issues/115))
 - `Options.IncludeHookEvents` field that enables hook lifecycle system messages (`hook_started`, `hook_progress`, `hook_response`) for all hook event types, forwarded as `--include-hook-events` to the CLI. Port of TypeScript SDK v0.2.89. ([#114](https://github.com/Flohs/claude-agent-sdk-go/issues/114))
 - Top-level `Options.Skills` field for enabling skills on the main session without manually configuring `AllowedTools` and `SettingSources`. Accepts `"all"` for every discovered skill or `[]string` of named skills. When set, the SDK auto-injects `Skill` / `Skill(name)` entries into `AllowedTools` and defaults `SettingSources` to `[user, project]` if unset. Port of Python SDK v0.1.62. ([#113](https://github.com/Flohs/claude-agent-sdk-go/issues/113))

--- a/options.go
+++ b/options.go
@@ -84,14 +84,29 @@ type ThinkingConfig interface {
 	thinkingConfigMarker()
 }
 
+// ThinkingDisplay controls whether thinking text is shown. Opus 4.7 defaults
+// to "omitted"; callers can opt in to "summarized" to receive summarized
+// thinking text.
+type ThinkingDisplay string
+
+const (
+	ThinkingDisplaySummarized ThinkingDisplay = "summarized"
+	ThinkingDisplayOmitted    ThinkingDisplay = "omitted"
+)
+
 // ThinkingConfigAdaptive enables adaptive thinking.
-type ThinkingConfigAdaptive struct{}
+type ThinkingConfigAdaptive struct {
+	// Display overrides the default thinking display behavior.
+	Display ThinkingDisplay `json:"display,omitempty"`
+}
 
 func (ThinkingConfigAdaptive) thinkingConfigMarker() {}
 
 // ThinkingConfigEnabled enables thinking with a specific budget.
 type ThinkingConfigEnabled struct {
 	BudgetTokens int `json:"budget_tokens"`
+	// Display overrides the default thinking display behavior.
+	Display ThinkingDisplay `json:"display,omitempty"`
 }
 
 func (ThinkingConfigEnabled) thinkingConfigMarker() {}

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -549,17 +549,23 @@ func (t *SubprocessTransport) buildCommand() []string {
 	}
 
 	// Thinking config
+	var thinkingDisplay ThinkingDisplay
 	if opts.Thinking != nil {
 		switch tc := opts.Thinking.(type) {
 		case ThinkingConfigAdaptive:
 			cmd = append(cmd, "--thinking", "adaptive")
+			thinkingDisplay = tc.Display
 		case ThinkingConfigDisabled:
 			cmd = append(cmd, "--thinking", "disabled")
 		case ThinkingConfigEnabled:
 			cmd = append(cmd, "--max-thinking-tokens", strconv.Itoa(tc.BudgetTokens))
+			thinkingDisplay = tc.Display
 		}
 	} else if opts.MaxThinkingTokens != nil {
 		cmd = append(cmd, "--max-thinking-tokens", strconv.Itoa(*opts.MaxThinkingTokens))
+	}
+	if thinkingDisplay != "" {
+		cmd = append(cmd, "--thinking-display", string(thinkingDisplay))
 	}
 
 	if opts.Effort != "" {

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -401,6 +401,32 @@ func TestBuildCommand_Skills(t *testing.T) {
 	})
 }
 
+func TestBuildCommand_ThinkingDisplay(t *testing.T) {
+	t.Run("no display omits flag", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{
+			Thinking: ThinkingConfigAdaptive{},
+		}}
+		cmd := transport.buildCommand()
+		assertNotContainsFlag(t, cmd, "--thinking-display")
+	})
+	t.Run("adaptive with summarized display", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{
+			Thinking: ThinkingConfigAdaptive{Display: ThinkingDisplaySummarized},
+		}}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--thinking", "adaptive")
+		assertContains(t, cmd, "--thinking-display", "summarized")
+	})
+	t.Run("enabled with omitted display", func(t *testing.T) {
+		transport := &SubprocessTransport{cliPath: "claude", options: &Options{
+			Thinking: ThinkingConfigEnabled{BudgetTokens: 2048, Display: ThinkingDisplayOmitted},
+		}}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--max-thinking-tokens", "2048")
+		assertContains(t, cmd, "--thinking-display", "omitted")
+	})
+}
+
 func TestBuildCommand_AgentProgressSummaries(t *testing.T) {
 	t.Run("false omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{cliPath: "claude", options: &Options{}}


### PR DESCRIPTION
Closes #116

## Summary
- Adds `ThinkingDisplay` type + constants `ThinkingDisplaySummarized`, `ThinkingDisplayOmitted`
- Adds `Display` field to `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`
- Forwarded as `--thinking-display`
- Port of Python SDK v0.1.65 (PR #830)

## Test plan
- [x] 3 new test cases
- [x] `go test -race ./...` clean