### PR TITLE
feat: add SandboxSettings.FailIfUnavailable (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `FailIfUnavailable` field on `SandboxSettings`. When set alongside `Enabled: true`, the CLI emits an error result instead of silently running commands unsandboxed on systems without bwrap/Seatbelt. Port of TypeScript SDK v0.2.91. ([#117](https://github.com/Flohs/claude-agent-sdk-go/issues/117))
 - `Display` field on `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`, plus `ThinkingDisplay` type with `ThinkingDisplaySummarized`/`ThinkingDisplayOmitted` constants. Forwarded as `--thinking-display` to let callers override Opus 4.7's default `omitted` thinking text. Port of Python SDK v0.1.65. ([#116](https://github.com/Flohs/claude-agent-sdk-go/issues/116))
 - `Options.AgentProgressSummaries` field that enables periodic AI-generated progress summaries on `task_progress` messages, forwarded as `--agent-progress-summaries`. Also adds a typed `Summary` field on `TaskProgressMessage`. Port of TypeScript SDK v0.2.72. ([#115](https://github.com/Flohs/claude-agent-sdk-go/issues/115))
 - `Options.IncludeHookEvents` field that enables hook lifecycle system messages (`hook_started`, `hook_progress`, `hook_response`) for all hook event types, forwarded as `--include-hook-events` to the CLI. Port of TypeScript SDK v0.2.89. ([#114](https://github.com/Flohs/claude-agent-sdk-go/issues/114))

--- a/options.go
+++ b/options.go
@@ -146,6 +146,12 @@ type SandboxSettings struct {
 	Network                    *SandboxNetworkConfig    `json:"network,omitempty"`
 	IgnoreViolations           *SandboxIgnoreViolations `json:"ignoreViolations,omitempty"`
 	EnableWeakerNestedSandbox  *bool                    `json:"enableWeakerNestedSandbox,omitempty"`
+	// FailIfUnavailable controls behavior when sandboxing is requested but the
+	// platform's sandbox mechanism is unavailable (no bwrap on Linux, no
+	// Seatbelt on macOS, etc). When true (the CLI default when Enabled is
+	// true), the CLI emits an error result message instead of silently running
+	// commands unsandboxed.
+	FailIfUnavailable *bool `json:"failIfUnavailable,omitempty"`
 }
 
 // Options configures a Claude SDK query or client.

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -401,6 +401,23 @@ func TestBuildCommand_Skills(t *testing.T) {
 	})
 }
 
+func TestBuildSettingsValue_SandboxFailIfUnavailable(t *testing.T) {
+	trueVal := true
+	transport := &SubprocessTransport{
+		cliPath: "claude",
+		options: &Options{
+			Sandbox: &SandboxSettings{
+				Enabled:           &trueVal,
+				FailIfUnavailable: &trueVal,
+			},
+		},
+	}
+	value := transport.buildSettingsValue()
+	if !strings.Contains(value, `"failIfUnavailable":true`) {
+		t.Errorf("expected failIfUnavailable in settings JSON, got %s", value)
+	}
+}
+
 func TestBuildCommand_ThinkingDisplay(t *testing.T) {
 	t.Run("no display omits flag", func(t *testing.T) {
 		transport := &SubprocessTransport{cliPath: "claude", options: &Options{


### PR DESCRIPTION
Closes #117

## Summary
- Adds `FailIfUnavailable *bool` on `SandboxSettings`
- Serialized via existing `--settings` JSON path
- Port of TypeScript SDK v0.2.91

## Test plan
- [x] Unit test verifies the field lands in the settings JSON
- [x] `go test -race ./...` clean