### PR TITLE
feat: add typed fields on AssistantMessage (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Typed `MessageID`, `SessionID`, `UUID`, and `StopReason` fields on `AssistantMessage`. Previously accessible only via `RawData`. Port of Python SDK PRs #619/#685/#718. ([#124](https://github.com/Flohs/claude-agent-sdk-go/issues/124))
 - `FailIfUnavailable` field on `SandboxSettings`. When set alongside `Enabled: true`, the CLI emits an error result instead of silently running commands unsandboxed on systems without bwrap/Seatbelt. Port of TypeScript SDK v0.2.91. ([#117](https://github.com/Flohs/claude-agent-sdk-go/issues/117))
 - `Display` field on `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`, plus `ThinkingDisplay` type with `ThinkingDisplaySummarized`/`ThinkingDisplayOmitted` constants. Forwarded as `--thinking-display` to let callers override Opus 4.7's default `omitted` thinking text. Port of Python SDK v0.1.65. ([#116](https://github.com/Flohs/claude-agent-sdk-go/issues/116))
 - `Options.AgentProgressSummaries` field that enables periodic AI-generated progress summaries on `task_progress` messages, forwarded as `--agent-progress-summaries`. Also adds a typed `Summary` field on `TaskProgressMessage`. Port of TypeScript SDK v0.2.72. ([#115](https://github.com/Flohs/claude-agent-sdk-go/issues/115))

--- a/message_parser.go
+++ b/message_parser.go
@@ -100,6 +100,10 @@ func parseAssistantMessage(data map[string]any) (*AssistantMessage, error) {
 		Content:         blocks,
 		Model:           model,
 		ParentToolUseID: stringField(data, "parent_tool_use_id"),
+		MessageID:       stringField(message, "id"),
+		SessionID:       stringField(data, "session_id"),
+		UUID:            stringField(data, "uuid"),
+		StopReason:      stringField(message, "stop_reason"),
 	}
 
 	if errStr := stringField(data, "error"); errStr != "" {

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -102,6 +102,41 @@ func TestParseMessage_AssistantMessage(t *testing.T) {
 	}
 }
 
+func TestParseMessage_AssistantMessage_TypedFields(t *testing.T) {
+	data := map[string]any{
+		"type":       "assistant",
+		"session_id": "sess-123",
+		"uuid":       "msg-uuid-abc",
+		"message": map[string]any{
+			"id":          "msg_01",
+			"model":       "claude-opus-4-7",
+			"stop_reason": "end_turn",
+			"content": []any{
+				map[string]any{"type": "text", "text": "done"},
+			},
+		},
+	}
+
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	asst := msg.(*AssistantMessage)
+
+	if asst.MessageID != "msg_01" {
+		t.Errorf("MessageID = %q, want msg_01", asst.MessageID)
+	}
+	if asst.SessionID != "sess-123" {
+		t.Errorf("SessionID = %q, want sess-123", asst.SessionID)
+	}
+	if asst.UUID != "msg-uuid-abc" {
+		t.Errorf("UUID = %q, want msg-uuid-abc", asst.UUID)
+	}
+	if asst.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", asst.StopReason)
+	}
+}
+
 func TestParseMessage_AssistantMessage_WithUsage(t *testing.T) {
 	data := map[string]any{
 		"type": "assistant",

--- a/types.go
+++ b/types.go
@@ -120,6 +120,16 @@ type AssistantMessage struct {
 	ParentToolUseID string                `json:"parent_tool_use_id,omitempty"`
 	Error           AssistantMessageError `json:"error,omitempty"`
 	Usage           map[string]any        `json:"usage,omitempty"`
+	// MessageID is the API-side message identifier (from the nested message
+	// object). Empty when not provided by the CLI.
+	MessageID string `json:"message_id,omitempty"`
+	// SessionID is the session this message belongs to.
+	SessionID string `json:"session_id,omitempty"`
+	// UUID uniquely identifies this message in the session transcript.
+	UUID string `json:"uuid,omitempty"`
+	// StopReason is why the model stopped generating (e.g. "end_turn",
+	// "tool_use", "max_tokens"). Empty when not provided.
+	StopReason string `json:"stop_reason,omitempty"`
 	// RawData contains the full raw message data for forward compatibility
 	// with fields not yet modeled by the SDK.
 	RawData map[string]any `json:"-"`


### PR DESCRIPTION
Closes #124

## Summary
- Adds `MessageID`, `SessionID`, `UUID`, `StopReason` as typed fields on `AssistantMessage`
- Parser populates them from `data.uuid`, `data.session_id`, `data.message.id`, `data.message.stop_reason`
- Port of Python SDK PRs #619/#685/#718

## Test plan
- [x] New test `TestParseMessage_AssistantMessage_TypedFields`
- [x] `go test -race ./...` clean