### PR TITLE
feat: add ResultMessage.TerminalReason (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `TerminalReason` field on `ResultMessage` (e.g. `completed`, `aborted_tools`, `max_turns`, `blocking_limit`). Previously accessible only via `RawData`. Port of TypeScript SDK v0.2.91. ([#125](https://github.com/Flohs/claude-agent-sdk-go/issues/125))
 - Typed `MessageID`, `SessionID`, `UUID`, and `StopReason` fields on `AssistantMessage`. Previously accessible only via `RawData`. Port of Python SDK PRs #619/#685/#718. ([#124](https://github.com/Flohs/claude-agent-sdk-go/issues/124))
 - `FailIfUnavailable` field on `SandboxSettings`. When set alongside `Enabled: true`, the CLI emits an error result instead of silently running commands unsandboxed on systems without bwrap/Seatbelt. Port of TypeScript SDK v0.2.91. ([#117](https://github.com/Flohs/claude-agent-sdk-go/issues/117))
 - `Display` field on `ThinkingConfigAdaptive` and `ThinkingConfigEnabled`, plus `ThinkingDisplay` type with `ThinkingDisplaySummarized`/`ThinkingDisplayOmitted` constants. Forwarded as `--thinking-display` to let callers override Opus 4.7's default `omitted` thinking text. Port of Python SDK v0.1.65. ([#116](https://github.com/Flohs/claude-agent-sdk-go/issues/116))

--- a/message_parser.go
+++ b/message_parser.go
@@ -184,14 +184,15 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 
 func parseResultMessage(data map[string]any) (*ResultMessage, error) {
 	msg := &ResultMessage{
-		Subtype:       stringField(data, "subtype"),
-		DurationMs:    intField(data, "duration_ms"),
-		DurationAPIMs: intField(data, "duration_api_ms"),
-		IsError:       boolField(data, "is_error"),
-		NumTurns:      intField(data, "num_turns"),
-		SessionID:     stringField(data, "session_id"),
-		StopReason:    stringField(data, "stop_reason"),
-		Result:        stringField(data, "result"),
+		Subtype:        stringField(data, "subtype"),
+		DurationMs:     intField(data, "duration_ms"),
+		DurationAPIMs:  intField(data, "duration_api_ms"),
+		IsError:        boolField(data, "is_error"),
+		NumTurns:       intField(data, "num_turns"),
+		SessionID:      stringField(data, "session_id"),
+		StopReason:     stringField(data, "stop_reason"),
+		TerminalReason: stringField(data, "terminal_reason"),
+		Result:         stringField(data, "result"),
 	}
 
 	if errors, ok := data["errors"].([]any); ok {

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -353,6 +353,27 @@ func TestParseMessage_ResultMessage(t *testing.T) {
 	}
 }
 
+func TestParseMessage_ResultMessage_TerminalReason(t *testing.T) {
+	data := map[string]any{
+		"type":            "result",
+		"subtype":         "success",
+		"duration_ms":     1000,
+		"duration_api_ms": 900,
+		"is_error":        false,
+		"num_turns":       1,
+		"session_id":      "s",
+		"terminal_reason": "max_turns",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := msg.(*ResultMessage)
+	if result.TerminalReason != "max_turns" {
+		t.Errorf("TerminalReason = %q, want max_turns", result.TerminalReason)
+	}
+}
+
 func TestParseMessage_ResultMessage_StopReasonPresent(t *testing.T) {
 	data := map[string]any{
 		"type":        "result",

--- a/types.go
+++ b/types.go
@@ -210,6 +210,10 @@ type ResultMessage struct {
 	NumTurns         int            `json:"num_turns"`
 	SessionID        string         `json:"session_id"`
 	StopReason       string         `json:"stop_reason,omitempty"`
+	// TerminalReason describes why the session terminated (e.g. "completed",
+	// "aborted_tools", "max_turns", "blocking_limit"). Empty when not
+	// provided by the CLI.
+	TerminalReason   string         `json:"terminal_reason,omitempty"`
 	TotalCostUSD     *float64       `json:"total_cost_usd,omitempty"`
 	Usage            map[string]any `json:"usage,omitempty"`
 	Result           string         `json:"result,omitempty"`


### PR DESCRIPTION
Closes #125

## Summary
- Adds `TerminalReason string` on `ResultMessage`
- Parser populates it from `terminal_reason`
- Port of TS SDK v0.2.91

## Test plan
- [x] New test covers the field
- [x] `go test -race ./...` clean