### PR TITLE
feat: add TeammateIdle/TaskCompleted/ConfigChange hook events (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- New hook event constants `HookEventTeammateIdle`, `HookEventTaskCompleted`, `HookEventConfigChange` with typed input structs `TeammateIdleHookInput`, `TaskCompletedHookInput`, `ConfigChangeHookInput`. Port of TypeScript SDK v0.2.33 and v0.2.49. ([#128](https://github.com/Flohs/claude-agent-sdk-go/issues/128))
 - `TerminalReason` field on `ResultMessage` (e.g. `completed`, `aborted_tools`, `max_turns`, `blocking_limit`). Previously accessible only via `RawData`. Port of TypeScript SDK v0.2.91. ([#125](https://github.com/Flohs/claude-agent-sdk-go/issues/125))
 - Typed `MessageID`, `SessionID`, `UUID`, and `StopReason` fields on `AssistantMessage`. Previously accessible only via `RawData`. Port of Python SDK PRs #619/#685/#718. ([#124](https://github.com/Flohs/claude-agent-sdk-go/issues/124))
 - `FailIfUnavailable` field on `SandboxSettings`. When set alongside `Enabled: true`, the CLI emits an error result instead of silently running commands unsandboxed on systems without bwrap/Seatbelt. Port of TypeScript SDK v0.2.91. ([#117](https://github.com/Flohs/claude-agent-sdk-go/issues/117))

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -94,6 +94,26 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			NotificationType: stringField(input, "notification_type"),
 		}, nil
 
+	case HookEventTeammateIdle:
+		return &TeammateIdleHookInput{
+			BaseHookInput:   base,
+			SubagentContext: parseSubagentContext(input),
+		}, nil
+
+	case HookEventTaskCompleted:
+		return &TaskCompletedHookInput{
+			BaseHookInput:   base,
+			SubagentContext: parseSubagentContext(input),
+			TaskID:          stringField(input, "task_id"),
+			ToolUseID:       stringField(input, "tool_use_id"),
+		}, nil
+
+	case HookEventConfigChange:
+		return &ConfigChangeHookInput{
+			BaseHookInput: base,
+			Changes:       mapField(input, "changes"),
+		}, nil
+
 	default:
 		// Forward-compatible: return nil for unrecognized events.
 		return nil, nil

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -19,6 +19,9 @@ var (
 	_ TypedHookInput = (*SubagentStartHookInput)(nil)
 	_ TypedHookInput = (*PreCompactHookInput)(nil)
 	_ TypedHookInput = (*NotificationHookInput)(nil)
+	_ TypedHookInput = (*TeammateIdleHookInput)(nil)
+	_ TypedHookInput = (*TaskCompletedHookInput)(nil)
+	_ TypedHookInput = (*ConfigChangeHookInput)(nil)
 )
 
 // base returns a HookInput with common fields pre-filled.
@@ -638,6 +641,67 @@ func TestPostToolUseFailureHookInput_JSONRoundTrip(t *testing.T) {
 	}
 	if typed.AgentID != "agent-99" {
 		t.Errorf("AgentID = %q, want %q", typed.AgentID, "agent-99")
+	}
+}
+
+func TestParseHookInput_TeammateIdle(t *testing.T) {
+	input := merge(base("TeammateIdle"), HookInput{
+		"agent_id":   "agent-7",
+		"agent_type": "researcher",
+	})
+	got, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed, ok := got.(*TeammateIdleHookInput)
+	if !ok {
+		t.Fatalf("expected *TeammateIdleHookInput, got %T", got)
+	}
+	assertBase(t, typed.BaseHookInput, "TeammateIdle")
+	if typed.AgentID != "agent-7" {
+		t.Errorf("AgentID = %q, want agent-7", typed.AgentID)
+	}
+}
+
+func TestParseHookInput_TaskCompleted(t *testing.T) {
+	input := merge(base("TaskCompleted"), HookInput{
+		"task_id":     "task-1",
+		"tool_use_id": "toolu_x",
+		"agent_id":    "agent-7",
+	})
+	got, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed, ok := got.(*TaskCompletedHookInput)
+	if !ok {
+		t.Fatalf("expected *TaskCompletedHookInput, got %T", got)
+	}
+	if typed.TaskID != "task-1" {
+		t.Errorf("TaskID = %q, want task-1", typed.TaskID)
+	}
+	if typed.ToolUseID != "toolu_x" {
+		t.Errorf("ToolUseID = %q, want toolu_x", typed.ToolUseID)
+	}
+}
+
+func TestParseHookInput_ConfigChange(t *testing.T) {
+	input := merge(base("ConfigChange"), HookInput{
+		"changes": map[string]any{
+			"permission_mode": "acceptEdits",
+			"model":           "claude-opus-4-7",
+		},
+	})
+	got, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	typed, ok := got.(*ConfigChangeHookInput)
+	if !ok {
+		t.Fatalf("expected *ConfigChangeHookInput, got %T", got)
+	}
+	if typed.Changes["permission_mode"] != "acceptEdits" {
+		t.Errorf("Changes[permission_mode] = %v, want acceptEdits", typed.Changes["permission_mode"])
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -16,6 +16,15 @@ const (
 	HookEventNotification        HookEvent = "Notification"
 	HookEventSubagentStart       HookEvent = "SubagentStart"
 	HookEventPermissionRequest   HookEvent = "PermissionRequest"
+	// HookEventTeammateIdle fires when a sub-agent idles waiting for input.
+	// Port of TypeScript SDK v0.2.33.
+	HookEventTeammateIdle HookEvent = "TeammateIdle"
+	// HookEventTaskCompleted fires when a Task-spawned sub-agent completes.
+	// Port of TypeScript SDK v0.2.33.
+	HookEventTaskCompleted HookEvent = "TaskCompleted"
+	// HookEventConfigChange fires when session configuration changes (e.g.
+	// permission mode switch, model change). Port of TypeScript SDK v0.2.49.
+	HookEventConfigChange HookEvent = "ConfigChange"
 )
 
 // HookInput represents the input data for a hook callback.
@@ -149,6 +158,35 @@ type NotificationHookInput struct {
 }
 
 func (*NotificationHookInput) hookInputMarker() {}
+
+// TeammateIdleHookInput is the typed input for TeammateIdle hook events.
+type TeammateIdleHookInput struct {
+	BaseHookInput
+	SubagentContext
+}
+
+func (*TeammateIdleHookInput) hookInputMarker() {}
+
+// TaskCompletedHookInput is the typed input for TaskCompleted hook events.
+type TaskCompletedHookInput struct {
+	BaseHookInput
+	SubagentContext
+	TaskID    string `json:"task_id,omitempty"`
+	ToolUseID string `json:"tool_use_id,omitempty"`
+}
+
+func (*TaskCompletedHookInput) hookInputMarker() {}
+
+// ConfigChangeHookInput is the typed input for ConfigChange hook events.
+type ConfigChangeHookInput struct {
+	BaseHookInput
+	// Changes carries the set of configuration keys that changed with their
+	// new values (e.g. {"permission_mode": "acceptEdits"}). The shape is
+	// preserved as a raw map to allow forward compatibility with new fields.
+	Changes map[string]any `json:"changes,omitempty"`
+}
+
+func (*ConfigChangeHookInput) hookInputMarker() {}
 
 // HookContext provides context for hook callbacks.
 type HookContext struct {


### PR DESCRIPTION
Closes #128

## Summary
- 3 new HookEvent constants
- 3 typed input structs
- Parser dispatches them
- Port of TS v0.2.33 + v0.2.49

## Test plan
- [x] 3 new parser tests
- [x] `go test -race ./...` clean