### PR TITLE
feat: add Client.ReloadPlugins (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Client.ReloadPlugins(ctx)` method that reloads plugins and returns refreshed commands, agents, and MCP server status via the `reload_plugins` control request. Port of TypeScript SDK v0.2.85. ([#118](https://github.com/Flohs/claude-agent-sdk-go/issues/118))
 - New hook event constants `HookEventTeammateIdle`, `HookEventTaskCompleted`, `HookEventConfigChange` with typed input structs `TeammateIdleHookInput`, `TaskCompletedHookInput`, `ConfigChangeHookInput`. Port of TypeScript SDK v0.2.33 and v0.2.49. ([#128](https://github.com/Flohs/claude-agent-sdk-go/issues/128))
 - `TerminalReason` field on `ResultMessage` (e.g. `completed`, `aborted_tools`, `max_turns`, `blocking_limit`). Previously accessible only via `RawData`. Port of TypeScript SDK v0.2.91. ([#125](https://github.com/Flohs/claude-agent-sdk-go/issues/125))
 - Typed `MessageID`, `SessionID`, `UUID`, and `StopReason` fields on `AssistantMessage`. Previously accessible only via `RawData`. Port of Python SDK PRs #619/#685/#718. ([#124](https://github.com/Flohs/claude-agent-sdk-go/issues/124))

--- a/client.go
+++ b/client.go
@@ -260,6 +260,15 @@ func (c *Client) GetContextUsage(ctx context.Context) (*ContextUsage, error) {
 	return c.q.getContextUsage()
 }
 
+// ReloadPlugins reloads plugins and returns refreshed commands, agents, and
+// MCP server status.
+func (c *Client) ReloadPlugins(ctx context.Context) (map[string]any, error) {
+	if c.q == nil {
+		return nil, &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+	return c.q.reloadPlugins()
+}
+
 // ReconnectMcpServer reconnects a disconnected or failed MCP server.
 func (c *Client) ReconnectMcpServer(ctx context.Context, name string) error {
 	if c.q == nil {

--- a/query.go
+++ b/query.go
@@ -591,6 +591,13 @@ func (q *query) getContextUsage() (*ContextUsage, error) {
 	return &usage, nil
 }
 
+func (q *query) reloadPlugins() (map[string]any, error) {
+	resp, err := q.sendControlRequest(map[string]any{
+		"subtype": "reload_plugins",
+	}, 60*time.Second)
+	return resp, err
+}
+
 func (q *query) reconnectMcpServer(serverName string) error {
 	_, err := q.sendControlRequest(map[string]any{
 		"subtype":    "mcp_reconnect",


### PR DESCRIPTION
Closes #118

## Summary
- New `Client.ReloadPlugins(ctx) (map[string]any, error)`
- Sends `{subtype: reload_plugins}` control request
- Port of TS SDK v0.2.85

## Test plan
- [x] `go build`, `go vet`, `go test -race ./...` clean