### PR TITLE
feat: add Client.EnableMcpChannel + Capabilities (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Client.EnableMcpChannel(ctx, serverName, channel)` method and `Capabilities []string` field on `McpServerStatus` for activating SDK-driven MCP channels. Port of TypeScript SDK v0.2.84. ([#119](https://github.com/Flohs/claude-agent-sdk-go/issues/119))
 - `Client.ReloadPlugins(ctx)` method that reloads plugins and returns refreshed commands, agents, and MCP server status via the `reload_plugins` control request. Port of TypeScript SDK v0.2.85. ([#118](https://github.com/Flohs/claude-agent-sdk-go/issues/118))
 - New hook event constants `HookEventTeammateIdle`, `HookEventTaskCompleted`, `HookEventConfigChange` with typed input structs `TeammateIdleHookInput`, `TaskCompletedHookInput`, `ConfigChangeHookInput`. Port of TypeScript SDK v0.2.33 and v0.2.49. ([#128](https://github.com/Flohs/claude-agent-sdk-go/issues/128))
 - `TerminalReason` field on `ResultMessage` (e.g. `completed`, `aborted_tools`, `max_turns`, `blocking_limit`). Previously accessible only via `RawData`. Port of TypeScript SDK v0.2.91. ([#125](https://github.com/Flohs/claude-agent-sdk-go/issues/125))

--- a/client.go
+++ b/client.go
@@ -269,6 +269,15 @@ func (c *Client) ReloadPlugins(ctx context.Context) (map[string]any, error) {
 	return c.q.reloadPlugins()
 }
 
+// EnableMcpChannel activates a capability channel on an MCP server. Available
+// channels for a given server are advertised in McpServerStatus.Capabilities.
+func (c *Client) EnableMcpChannel(ctx context.Context, serverName, channel string) error {
+	if c.q == nil {
+		return &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+	return c.q.enableMcpChannel(serverName, channel)
+}
+
 // ReconnectMcpServer reconnects a disconnected or failed MCP server.
 func (c *Client) ReconnectMcpServer(ctx context.Context, name string) error {
 	if c.q == nil {

--- a/mcp.go
+++ b/mcp.go
@@ -136,6 +136,9 @@ type McpServerStatus struct {
 	Config     map[string]any            `json:"config,omitempty"`
 	Scope      string                    `json:"scope,omitempty"`
 	Tools      []McpToolInfo             `json:"tools,omitempty"`
+	// Capabilities lists the SDK-driven channels this MCP server can activate.
+	// Use Client.EnableChannel to activate one of the listed capabilities.
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // McpStatusResponse is the response from GetMcpStatus.

--- a/query.go
+++ b/query.go
@@ -598,6 +598,15 @@ func (q *query) reloadPlugins() (map[string]any, error) {
 	return resp, err
 }
 
+func (q *query) enableMcpChannel(serverName, channel string) error {
+	_, err := q.sendControlRequest(map[string]any{
+		"subtype":    "mcp_enable_channel",
+		"serverName": serverName,
+		"channel":    channel,
+	}, 60*time.Second)
+	return err
+}
+
 func (q *query) reconnectMcpServer(serverName string) error {
 	_, err := q.sendControlRequest(map[string]any{
 		"subtype":    "mcp_reconnect",


### PR DESCRIPTION
Closes #119

## Summary
- New `Client.EnableMcpChannel(ctx, serverName, channel)`
- `Capabilities []string` on `McpServerStatus`
- Port of TS SDK v0.2.84

## Test plan
- [x] Build/vet/test clean