### PR TITLE
feat: add Client.SupportedAgents + SupportedCommands (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Client.SupportedAgents(ctx)` and `Client.SupportedCommands(ctx)` methods for querying available subagents and slash commands in the running session. Port of TypeScript SDK v0.2.63 / v0.2.74. ([#120](https://github.com/Flohs/claude-agent-sdk-go/issues/120))
 - `Client.EnableMcpChannel(ctx, serverName, channel)` method and `Capabilities []string` field on `McpServerStatus` for activating SDK-driven MCP channels. Port of TypeScript SDK v0.2.84. ([#119](https://github.com/Flohs/claude-agent-sdk-go/issues/119))
 - `Client.ReloadPlugins(ctx)` method that reloads plugins and returns refreshed commands, agents, and MCP server status via the `reload_plugins` control request. Port of TypeScript SDK v0.2.85. ([#118](https://github.com/Flohs/claude-agent-sdk-go/issues/118))
 - New hook event constants `HookEventTeammateIdle`, `HookEventTaskCompleted`, `HookEventConfigChange` with typed input structs `TeammateIdleHookInput`, `TaskCompletedHookInput`, `ConfigChangeHookInput`. Port of TypeScript SDK v0.2.33 and v0.2.49. ([#128](https://github.com/Flohs/claude-agent-sdk-go/issues/128))

--- a/client.go
+++ b/client.go
@@ -278,6 +278,23 @@ func (c *Client) EnableMcpChannel(ctx context.Context, serverName, channel strin
 	return c.q.enableMcpChannel(serverName, channel)
 }
 
+// SupportedAgents returns the list of subagent names available in the session.
+func (c *Client) SupportedAgents(ctx context.Context) ([]string, error) {
+	if c.q == nil {
+		return nil, &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+	return c.q.supportedAgents()
+}
+
+// SupportedCommands returns the list of slash command names available in the
+// session (including plugin-provided commands).
+func (c *Client) SupportedCommands(ctx context.Context) ([]string, error) {
+	if c.q == nil {
+		return nil, &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+	return c.q.supportedCommands()
+}
+
 // ReconnectMcpServer reconnects a disconnected or failed MCP server.
 func (c *Client) ReconnectMcpServer(ctx context.Context, name string) error {
 	if c.q == nil {

--- a/query.go
+++ b/query.go
@@ -607,6 +607,40 @@ func (q *query) enableMcpChannel(serverName, channel string) error {
 	return err
 }
 
+func (q *query) supportedAgents() ([]string, error) {
+	resp, err := q.sendControlRequest(map[string]any{
+		"subtype": "supported_agents",
+	}, 60*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	return stringSliceFromResponse(resp, "agents")
+}
+
+func (q *query) supportedCommands() ([]string, error) {
+	resp, err := q.sendControlRequest(map[string]any{
+		"subtype": "supported_commands",
+	}, 60*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	return stringSliceFromResponse(resp, "commands")
+}
+
+func stringSliceFromResponse(resp map[string]any, key string) ([]string, error) {
+	raw, ok := resp[key].([]any)
+	if !ok {
+		return nil, nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
 func (q *query) reconnectMcpServer(serverName string) error {
 	_, err := q.sendControlRequest(map[string]any{
 		"subtype":    "mcp_reconnect",


### PR DESCRIPTION
Closes #120

## Summary
- Two new control-request methods returning `[]string`
- Port of TS SDK v0.2.63 / v0.2.74

## Test plan
- [x] Build/vet/test clean