### PR TITLE
feat: add Client.SeedReadState (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Client.SeedReadState(ctx, entries)` method and `ReadStateEntry` type. Sends the `seed_read_state` control request to populate the CLI's `readFileState` with path/mtime pairs so Edit-style tools work across context compactions. Port of TypeScript SDK v0.2.83. ([#123](https://github.com/Flohs/claude-agent-sdk-go/issues/123))
 - `Client.StopAsyncMessage(ctx, uuid)` method that drops a queued user message by UUID before it reaches execution via the `cancel_async_message` control request. Port of TypeScript SDK v0.2.76. ([#122](https://github.com/Flohs/claude-agent-sdk-go/issues/122))
 - `Client.PromptSuggestion(ctx)` method that requests prompt suggestions based on the current conversation context. Port of TypeScript SDK v0.2.47. ([#121](https://github.com/Flohs/claude-agent-sdk-go/issues/121))
 - `Client.SupportedAgents(ctx)` and `Client.SupportedCommands(ctx)` methods for querying available subagents and slash commands in the running session. Port of TypeScript SDK v0.2.63 / v0.2.74. ([#120](https://github.com/Flohs/claude-agent-sdk-go/issues/120))

--- a/client.go
+++ b/client.go
@@ -313,6 +313,16 @@ func (c *Client) StopAsyncMessage(ctx context.Context, uuid string) error {
 	return c.q.stopAsyncMessage(uuid)
 }
 
+// SeedReadState seeds the CLI's read-file-state tracker with the given
+// entries so Edit-style tools can operate across context compactions
+// without first requiring a fresh Read.
+func (c *Client) SeedReadState(ctx context.Context, entries []ReadStateEntry) error {
+	if c.q == nil {
+		return &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+	return c.q.seedReadState(entries)
+}
+
 // ReconnectMcpServer reconnects a disconnected or failed MCP server.
 func (c *Client) ReconnectMcpServer(ctx context.Context, name string) error {
 	if c.q == nil {

--- a/query.go
+++ b/query.go
@@ -645,6 +645,18 @@ func (q *query) stopAsyncMessage(uuid string) error {
 	return err
 }
 
+func (q *query) seedReadState(entries []ReadStateEntry) error {
+	payload := make([]map[string]any, len(entries))
+	for i, e := range entries {
+		payload[i] = map[string]any{"path": e.Path, "mtime": e.Mtime}
+	}
+	_, err := q.sendControlRequest(map[string]any{
+		"subtype": "seed_read_state",
+		"entries": payload,
+	}, 60*time.Second)
+	return err
+}
+
 func stringSliceFromResponse(resp map[string]any, key string) ([]string, error) {
 	raw, ok := resp[key].([]any)
 	if !ok {

--- a/types.go
+++ b/types.go
@@ -286,6 +286,15 @@ type SDKSessionInfo struct {
 	CreatedAt    *int64  `json:"created_at,omitempty"`
 }
 
+// ReadStateEntry is a single file-state record used by
+// [Client.SeedReadState]. It tells the CLI which files the caller has read
+// out-of-band so that Edit-style tools can operate across context
+// compactions without a fresh Read.
+type ReadStateEntry struct {
+	Path  string `json:"path"`
+	Mtime int64  `json:"mtime"`
+}
+
 // SessionMessage represents a user or assistant message from a session transcript.
 type SessionMessage struct {
 	Type            string `json:"type"` // "user" or "assistant"


### PR DESCRIPTION
Closes #123

## Summary
- `ReadStateEntry{Path, Mtime}` type
- `Client.SeedReadState(ctx, entries) error` control request
- Port of TS SDK v0.2.83

## Test plan
- [x] Build/vet/test clean