### PR TITLE
fix: parse server-side tool content blocks (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `ServerToolUseBlock` and `ServerToolResultBlock` content block types and `ServerToolName` enum constants (`advisor`, `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `tool_search_tool_regex`, `tool_search_tool_bm25`). Port of Python SDK v0.1.65 / PR #836. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))
 - `Client.SeedReadState(ctx, entries)` method and `ReadStateEntry` type. Sends the `seed_read_state` control request to populate the CLI's `readFileState` with path/mtime pairs so Edit-style tools work across context compactions. Port of TypeScript SDK v0.2.83. ([#123](https://github.com/Flohs/claude-agent-sdk-go/issues/123))
 - `Client.StopAsyncMessage(ctx, uuid)` method that drops a queued user message by UUID before it reaches execution via the `cancel_async_message` control request. Port of TypeScript SDK v0.2.76. ([#122](https://github.com/Flohs/claude-agent-sdk-go/issues/122))
 - `Client.PromptSuggestion(ctx)` method that requests prompt suggestions based on the current conversation context. Port of TypeScript SDK v0.2.47. ([#121](https://github.com/Flohs/claude-agent-sdk-go/issues/121))
@@ -27,6 +28,8 @@
 - `DeleteSession` now also removes the sibling `{session_id}/` directory (where subagent transcripts live) on a best-effort basis, matching the Python SDK and TypeScript SDK. Failures removing the sibling directory are swallowed so the primary `.jsonl` delete still counts. Port of Python SDK [anthropics/claude-agent-sdk-python#805](https://github.com/anthropics/claude-agent-sdk-python/pull/805). ([#105](https://github.com/Flohs/claude-agent-sdk-go/issues/105))
 
 ### Fixed
+
+- Assistant messages containing server-side tool blocks (`web_search`, `web_fetch`, `advisor`, etc.) previously had those blocks silently dropped by the content parser, which could produce `AssistantMessage{Content: []}` for messages that only carried server-tool blocks. The parser now emits typed `ServerToolUseBlock` / `ServerToolResultBlock` blocks. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))
 
 - `ThinkingConfigAdaptive` and `ThinkingConfigDisabled` now correctly map to `--thinking adaptive` / `--thinking disabled` CLI flags instead of incorrectly using `--max-thinking-tokens`. `ThinkingConfigEnabled` and the deprecated `MaxThinkingTokens` field continue to use `--max-thinking-tokens`. ([#99](https://github.com/Flohs/claude-agent-sdk-go/issues/99))
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -282,6 +282,22 @@ func parseContentBlocks(raw []any) ([]ContentBlock, error) {
 				block.IsError = &isErr
 			}
 			blocks = append(blocks, block)
+		case "server_tool_use":
+			id, _ := blockMap["id"].(string)
+			name, _ := blockMap["name"].(string)
+			input, _ := blockMap["input"].(map[string]any)
+			blocks = append(blocks, ServerToolUseBlock{
+				ID:    id,
+				Name:  ServerToolName(name),
+				Input: input,
+			})
+		case "advisor_tool_result", "server_tool_result":
+			toolUseID, _ := blockMap["tool_use_id"].(string)
+			content, _ := blockMap["content"].(map[string]any)
+			blocks = append(blocks, ServerToolResultBlock{
+				ToolUseID: toolUseID,
+				Content:   content,
+			})
 		}
 	}
 	return blocks, nil

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -102,6 +102,53 @@ func TestParseMessage_AssistantMessage(t *testing.T) {
 	}
 }
 
+func TestParseMessage_AssistantMessage_ServerToolUseAndResult(t *testing.T) {
+	data := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"model": "claude-opus-4-7",
+			"content": []any{
+				map[string]any{
+					"type":  "server_tool_use",
+					"id":    "srvtooluse_1",
+					"name":  "web_search",
+					"input": map[string]any{"query": "golang generics"},
+				},
+				map[string]any{
+					"type":        "advisor_tool_result",
+					"tool_use_id": "srvtooluse_1",
+					"content":     map[string]any{"type": "web_search_result", "results": []any{}},
+				},
+			},
+		},
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	asst := msg.(*AssistantMessage)
+	if len(asst.Content) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(asst.Content))
+	}
+	server, ok := asst.Content[0].(ServerToolUseBlock)
+	if !ok {
+		t.Fatalf("expected ServerToolUseBlock, got %T", asst.Content[0])
+	}
+	if server.Name != ServerToolWebSearch {
+		t.Errorf("Name = %q, want %q", server.Name, ServerToolWebSearch)
+	}
+	result, ok := asst.Content[1].(ServerToolResultBlock)
+	if !ok {
+		t.Fatalf("expected ServerToolResultBlock, got %T", asst.Content[1])
+	}
+	if result.ToolUseID != "srvtooluse_1" {
+		t.Errorf("ToolUseID = %q, want %q", result.ToolUseID, "srvtooluse_1")
+	}
+	if result.Content["type"] != "web_search_result" {
+		t.Errorf("Content[type] = %v, want web_search_result", result.Content["type"])
+	}
+}
+
 func TestParseMessage_AssistantMessage_TypedFields(t *testing.T) {
 	data := map[string]any{
 		"type":       "assistant",

--- a/types.go
+++ b/types.go
@@ -91,6 +91,43 @@ type ToolResultBlock struct {
 
 func (ToolResultBlock) contentBlockMarker() {}
 
+// ServerToolName names one of the server-side tools the API can invoke on
+// the model's behalf. Callers branch on Name to know which tool was used.
+type ServerToolName string
+
+const (
+	ServerToolAdvisor                 ServerToolName = "advisor"
+	ServerToolWebSearch               ServerToolName = "web_search"
+	ServerToolWebFetch                ServerToolName = "web_fetch"
+	ServerToolCodeExecution           ServerToolName = "code_execution"
+	ServerToolBashCodeExecution       ServerToolName = "bash_code_execution"
+	ServerToolTextEditorCodeExecution ServerToolName = "text_editor_code_execution"
+	ServerToolSearchRegex             ServerToolName = "tool_search_tool_regex"
+	ServerToolSearchBM25              ServerToolName = "tool_search_tool_bm25"
+)
+
+// ServerToolUseBlock represents a server-side tool use (e.g. advisor,
+// web_search, web_fetch). These tools execute server-side on the model's
+// behalf; the caller never needs to return a result.
+type ServerToolUseBlock struct {
+	ID    string         `json:"id"`
+	Name  ServerToolName `json:"name"`
+	Input map[string]any `json:"input"`
+}
+
+func (ServerToolUseBlock) contentBlockMarker() {}
+
+// ServerToolResultBlock represents the result of a server-side tool call
+// (e.g. advisor_tool_result). Content is the raw payload from the API;
+// callers that care about a specific tool's result schema can inspect
+// Content["type"].
+type ServerToolResultBlock struct {
+	ToolUseID string         `json:"tool_use_id"`
+	Content   map[string]any `json:"content,omitempty"`
+}
+
+func (ServerToolResultBlock) contentBlockMarker() {}
+
 // UserMessage represents a user message.
 type UserMessage struct {
 	Content          any            `json:"content"`                      // string | []ContentBlock


### PR DESCRIPTION
Closes #109

## Summary
- New `ServerToolUseBlock`, `ServerToolResultBlock` content block types
- New `ServerToolName` enum (`advisor`, `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `tool_search_tool_regex`, `tool_search_tool_bm25`)
- Parser handles `server_tool_use`, `advisor_tool_result`, and `server_tool_result` block types
- Port of Python SDK v0.1.65 / PR #836

## Bug fix
Previously, assistant messages containing only server-side tool blocks arrived as `AssistantMessage{Content: []}` — silent data loss.

## Test plan
- [x] New test `TestParseMessage_AssistantMessage_ServerToolUseAndResult`
- [x] `go test -race ./...` clean