### PR TITLE
feat: add GetSessionMessagesOptions.IncludeSystemMessages (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `IncludeSystemMessages` field on `GetSessionMessagesOptions`. When set, system-subtype transcript entries (task notifications, hook events, etc.) are included in the returned slice. Port of TypeScript SDK v0.2.89. ([#127](https://github.com/Flohs/claude-agent-sdk-go/issues/127))
 - `ServerToolUseBlock` and `ServerToolResultBlock` content block types and `ServerToolName` enum constants (`advisor`, `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `tool_search_tool_regex`, `tool_search_tool_bm25`). Port of Python SDK v0.1.65 / PR #836. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))
 - `Client.SeedReadState(ctx, entries)` method and `ReadStateEntry` type. Sends the `seed_read_state` control request to populate the CLI's `readFileState` with path/mtime pairs so Edit-style tools work across context compactions. Port of TypeScript SDK v0.2.83. ([#123](https://github.com/Flohs/claude-agent-sdk-go/issues/123))
 - `Client.StopAsyncMessage(ctx, uuid)` method that drops a queued user message by UUID before it reaches execution via the `cancel_async_message` control request. Port of TypeScript SDK v0.2.76. ([#122](https://github.com/Flohs/claude-agent-sdk-go/issues/122))

--- a/sessions.go
+++ b/sessions.go
@@ -47,6 +47,11 @@ type GetSessionMessagesOptions struct {
 	Directory string
 	Limit     *int
 	Offset    int
+	// IncludeSystemMessages includes system-subtype transcript entries
+	// (hooks, summaries, status updates, etc.) in the returned slice.
+	// Default is false, which matches the prior user+assistant-only
+	// behavior.
+	IncludeSystemMessages bool
 }
 
 // ListSessions lists sessions with metadata extracted from stat + head/tail reads.
@@ -75,6 +80,10 @@ func GetSessionMessages(sessionID string, opts GetSessionMessagesOptions) ([]Ses
 	var visible []transcriptEntry
 	for _, e := range chain {
 		if isVisibleMessage(e) {
+			visible = append(visible, e)
+			continue
+		}
+		if opts.IncludeSystemMessages && isVisibleSystemMessage(e) {
 			visible = append(visible, e)
 		}
 	}
@@ -999,11 +1008,28 @@ func isVisibleMessage(entry transcriptEntry) bool {
 	return !hasTeam
 }
 
+func isVisibleSystemMessage(entry transcriptEntry) bool {
+	entryType, _ := entry["type"].(string)
+	if entryType != "system" {
+		return false
+	}
+	if isMeta, _ := entry["isMeta"].(bool); isMeta {
+		return false
+	}
+	if isSidechain, _ := entry["isSidechain"].(bool); isSidechain {
+		return false
+	}
+	return true
+}
+
 func toSessionMessage(entry transcriptEntry) SessionMessage {
 	entryType, _ := entry["type"].(string)
 	msgType := "user"
-	if entryType == "assistant" {
+	switch entryType {
+	case "assistant":
 		msgType = "assistant"
+	case "system":
+		msgType = "system"
 	}
 	uuid, _ := entry["uuid"].(string)
 	sessionID, _ := entry["sessionId"].(string)

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -209,6 +209,24 @@ func makeUserLine(uuid, parentUUID, content string, extra ...map[string]any) str
 	return makeSessionLine(m)
 }
 
+// makeSystemLine creates a system message transcript line.
+func makeSystemLine(uuid, parentUUID, subtype string, extra ...map[string]any) string {
+	m := map[string]any{
+		"type":    "system",
+		"uuid":    uuid,
+		"subtype": subtype,
+	}
+	if parentUUID != "" {
+		m["parentUuid"] = parentUUID
+	}
+	for _, e := range extra {
+		for k, v := range e {
+			m[k] = v
+		}
+	}
+	return makeSessionLine(m)
+}
+
 // makeAssistantLine creates an assistant message transcript line.
 func makeAssistantLine(uuid, parentUUID, content string, extra ...map[string]any) string {
 	m := map[string]any{
@@ -986,6 +1004,54 @@ func TestGetSessionMessages_NonexistentSession(t *testing.T) {
 	if messages != nil {
 		t.Errorf("expected nil for nonexistent session, got %v", messages)
 	}
+}
+
+func TestGetSessionMessages_IncludeSystemMessages(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/system")
+
+	// Chain: u1 -> a1 -> s1 (system) -> u2 -> a2
+	content := strings.Join([]string{
+		makeUserLine("u1", "", "Q1"),
+		makeAssistantLine("a1", "u1", "A1"),
+		makeSystemLine("s1", "a1", "task_notification"),
+		makeUserLine("u2", "s1", "Q2"),
+		makeAssistantLine("a2", "u2", "A2"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, testUUID1, content)
+
+	t.Run("default excludes system messages", func(t *testing.T) {
+		messages, err := GetSessionMessages(testUUID1, GetSessionMessagesOptions{Directory: "/test/system"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(messages) != 4 {
+			t.Fatalf("expected 4 user+assistant messages, got %d", len(messages))
+		}
+		for _, m := range messages {
+			if m.Type == "system" {
+				t.Errorf("did not expect system message in default output, got %+v", m)
+			}
+		}
+	})
+
+	t.Run("IncludeSystemMessages includes them", func(t *testing.T) {
+		messages, err := GetSessionMessages(testUUID1, GetSessionMessagesOptions{
+			Directory:             "/test/system",
+			IncludeSystemMessages: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var foundSystem bool
+		for _, m := range messages {
+			if m.Type == "system" {
+				foundSystem = true
+			}
+		}
+		if !foundSystem {
+			t.Errorf("expected at least one system message in output, got %d messages", len(messages))
+		}
+	})
 }
 
 func TestGetSessionMessages_WithOffset(t *testing.T) {


### PR DESCRIPTION
Closes #127

## Summary
- New `IncludeSystemMessages bool` on `GetSessionMessagesOptions`
- When true, system-subtype transcript entries that are in the conversation chain are included
- Port of TS SDK v0.2.89

## Test plan
- [x] `TestGetSessionMessages_IncludeSystemMessages` covers both default and opt-in paths
- [x] `go test -race ./...` clean