### PR TITLE
feat: add ListSubagents + GetSubagentMessages (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `ListSubagents(sessionID, opts)` and `GetSubagentMessages(sessionID, agentID, opts)` session helpers for reading subagent transcripts from the sibling `{session_id}/subagents/` directory (supports nested layouts such as `workflows/<runId>/`). Port of Python SDK v0.1.60 / PR #825. ([#126](https://github.com/Flohs/claude-agent-sdk-go/issues/126))
 - `IncludeSystemMessages` field on `GetSessionMessagesOptions`. When set, system-subtype transcript entries (task notifications, hook events, etc.) are included in the returned slice. Port of TypeScript SDK v0.2.89. ([#127](https://github.com/Flohs/claude-agent-sdk-go/issues/127))
 - `ServerToolUseBlock` and `ServerToolResultBlock` content block types and `ServerToolName` enum constants (`advisor`, `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `tool_search_tool_regex`, `tool_search_tool_bm25`). Port of Python SDK v0.1.65 / PR #836. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))
 - `Client.SeedReadState(ctx, entries)` method and `ReadStateEntry` type. Sends the `seed_read_state` control request to populate the CLI's `readFileState` with path/mtime pairs so Edit-style tools work across context compactions. Port of TypeScript SDK v0.2.83. ([#123](https://github.com/Flohs/claude-agent-sdk-go/issues/123))

--- a/sessions.go
+++ b/sessions.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,6 +41,143 @@ type ListSessionsOptions struct {
 	Limit            *int
 	Offset           int
 	IncludeWorktrees bool // defaults to true
+}
+
+// ListSubagentsOptions configures subagent listing.
+type ListSubagentsOptions struct {
+	// Directory scopes the search to a specific project directory (and its
+	// worktrees). When empty, all project directories are searched.
+	Directory string
+}
+
+// GetSubagentMessagesOptions configures subagent transcript retrieval.
+type GetSubagentMessagesOptions struct {
+	Directory             string
+	Limit                 *int
+	Offset                int
+	IncludeSystemMessages bool
+}
+
+// ListSubagents returns the agent IDs of subagents that wrote transcripts
+// during the given session. Subagent transcripts live at
+// `<projectDir>/<sessionId>/subagents/agent-<agentId>.jsonl` (and may be
+// nested under subdirectories such as `workflows/<runId>/`).
+//
+// Returns an empty slice when the session is not found, the sessionID is
+// not a valid UUID, or the session has no subagents.
+func ListSubagents(sessionID string, opts ListSubagentsOptions) []string {
+	if !isValidUUID(sessionID) {
+		return nil
+	}
+	subagentsDir := resolveSubagentsDir(sessionID, opts.Directory)
+	if subagentsDir == "" {
+		return nil
+	}
+	files := collectAgentFiles(subagentsDir)
+	ids := make([]string, 0, len(files))
+	for _, af := range files {
+		ids = append(ids, af.agentID)
+	}
+	return ids
+}
+
+// GetSubagentMessages reads a single subagent's conversation from its JSONL
+// transcript. Messages are returned in chronological order with the same
+// filtering behavior as GetSessionMessages (user/assistant by default;
+// system entries added when IncludeSystemMessages is set).
+func GetSubagentMessages(sessionID, agentID string, opts GetSubagentMessagesOptions) ([]SessionMessage, error) {
+	if !isValidUUID(sessionID) {
+		return nil, nil
+	}
+	subagentsDir := resolveSubagentsDir(sessionID, opts.Directory)
+	if subagentsDir == "" {
+		return nil, nil
+	}
+	var agentFile string
+	for _, af := range collectAgentFiles(subagentsDir) {
+		if af.agentID == agentID {
+			agentFile = af.path
+			break
+		}
+	}
+	if agentFile == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(agentFile)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := parseTranscriptEntries(string(data))
+	chain := buildConversationChain(entries)
+
+	var visible []transcriptEntry
+	for _, e := range chain {
+		if isVisibleMessage(e) {
+			visible = append(visible, e)
+			continue
+		}
+		if opts.IncludeSystemMessages && isVisibleSystemMessage(e) {
+			visible = append(visible, e)
+		}
+	}
+
+	messages := make([]SessionMessage, len(visible))
+	for i, e := range visible {
+		messages[i] = toSessionMessage(e)
+	}
+
+	if opts.Offset > 0 {
+		if opts.Offset >= len(messages) {
+			return nil, nil
+		}
+		messages = messages[opts.Offset:]
+	}
+	if opts.Limit != nil && *opts.Limit > 0 && *opts.Limit < len(messages) {
+		messages = messages[:*opts.Limit]
+	}
+	return messages, nil
+}
+
+// resolveSubagentsDir returns the on-disk path of the `subagents/` folder
+// for a given session, or "" if the session file cannot be located.
+func resolveSubagentsDir(sessionID, directory string) string {
+	filePath := findSessionFilePath(sessionID, directory)
+	if filePath == "" {
+		return ""
+	}
+	// Strip the .jsonl suffix to derive the session directory.
+	sessionDir := strings.TrimSuffix(filePath, ".jsonl")
+	return filepath.Join(sessionDir, "subagents")
+}
+
+type agentFile struct {
+	agentID string
+	path    string
+}
+
+// collectAgentFiles walks a subagents directory tree and returns every
+// `agent-<id>.jsonl` file it finds. Agent IDs are extracted from the
+// filename. Results are sorted by filename for deterministic ordering.
+func collectAgentFiles(baseDir string) []agentFile {
+	var result []agentFile
+	_ = filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasPrefix(name, "agent-") || !strings.HasSuffix(name, ".jsonl") {
+			return nil
+		}
+		id := strings.TrimSuffix(strings.TrimPrefix(name, "agent-"), ".jsonl")
+		result = append(result, agentFile{agentID: id, path: path})
+		return nil
+	})
+	return result
 }
 
 // GetSessionMessagesOptions configures session message retrieval.

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -1006,6 +1006,88 @@ func TestGetSessionMessages_NonexistentSession(t *testing.T) {
 	}
 }
 
+func TestListSubagents_AndGetSubagentMessages(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/subagents")
+
+	// Write parent session file
+	parentContent := makeUserLine("u1", "", "parent") + "\n"
+	writeSessionFile(t, projDir, testUUID1, parentContent)
+
+	// Write subagent transcripts
+	subagentsDir := filepath.Join(projDir, testUUID1, "subagents")
+	if err := os.MkdirAll(subagentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agentA := filepath.Join(subagentsDir, "agent-abc.jsonl")
+	agentAContent := strings.Join([]string{
+		makeUserLine("au1", "", "sub Q"),
+		makeAssistantLine("aa1", "au1", "sub A"),
+	}, "\n") + "\n"
+	if err := os.WriteFile(agentA, []byte(agentAContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nested agent
+	nestedDir := filepath.Join(subagentsDir, "workflows", "run-1")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentB := filepath.Join(nestedDir, "agent-xyz.jsonl")
+	agentBContent := strings.Join([]string{
+		makeUserLine("bu1", "", "nested Q"),
+		makeAssistantLine("ba1", "bu1", "nested A"),
+	}, "\n") + "\n"
+	if err := os.WriteFile(agentB, []byte(agentBContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("list discovers nested agent files", func(t *testing.T) {
+		ids := ListSubagents(testUUID1, ListSubagentsOptions{Directory: "/test/subagents"})
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 agent IDs, got %d: %v", len(ids), ids)
+		}
+		has := map[string]bool{}
+		for _, id := range ids {
+			has[id] = true
+		}
+		if !has["abc"] || !has["xyz"] {
+			t.Errorf("expected agent IDs abc+xyz, got %v", ids)
+		}
+	})
+
+	t.Run("get messages for a named agent", func(t *testing.T) {
+		msgs, err := GetSubagentMessages(testUUID1, "abc", GetSubagentMessagesOptions{
+			Directory: "/test/subagents",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(msgs))
+		}
+	})
+
+	t.Run("invalid UUID returns empty", func(t *testing.T) {
+		ids := ListSubagents("not-a-uuid", ListSubagentsOptions{})
+		if ids != nil {
+			t.Errorf("expected nil for invalid UUID, got %v", ids)
+		}
+	})
+
+	t.Run("unknown agent returns nil", func(t *testing.T) {
+		msgs, err := GetSubagentMessages(testUUID1, "missing", GetSubagentMessagesOptions{
+			Directory: "/test/subagents",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if msgs != nil {
+			t.Errorf("expected nil for missing agent, got %d messages", len(msgs))
+		}
+	})
+}
+
 func TestGetSessionMessages_IncludeSystemMessages(t *testing.T) {
 	projDir := setupTestProjectDir(t, "/test/system")
 


### PR DESCRIPTION
Closes #126

## Summary
- `ListSubagents(sessionID, opts) []string`
- `GetSubagentMessages(sessionID, agentID, opts) ([]SessionMessage, error)`
- `ListSubagentsOptions`, `GetSubagentMessagesOptions` with Directory / Limit / Offset / IncludeSystemMessages
- Recursively walks `{sessionDir}/subagents/` for `agent-<id>.jsonl` files
- Port of Python SDK v0.1.60 / PR #825

## Test plan
- [x] `TestListSubagents_AndGetSubagentMessages` with 4 sub-cases (including nested `workflows/run-1/` layout)
- [x] `go test -race ./...` clean