### PR TITLE
feat: add W3C trace context propagation (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `Options.TraceParent` and `Options.TraceState` fields for W3C trace context propagation to the CLI subprocess (forwarded as `TRACEPARENT` / `TRACESTATE` env vars). OpenTelemetry users can inject the active span context; when unset, externally-set trace env vars still flow through the inherited environment. Port of Python SDK v0.1.60 / PR #821 and TypeScript SDK v0.2.113. ([#129](https://github.com/Flohs/claude-agent-sdk-go/issues/129))
 - `ListSubagents(sessionID, opts)` and `GetSubagentMessages(sessionID, agentID, opts)` session helpers for reading subagent transcripts from the sibling `{session_id}/subagents/` directory (supports nested layouts such as `workflows/<runId>/`). Port of Python SDK v0.1.60 / PR #825. ([#126](https://github.com/Flohs/claude-agent-sdk-go/issues/126))
 - `IncludeSystemMessages` field on `GetSessionMessagesOptions`. When set, system-subtype transcript entries (task notifications, hook events, etc.) are included in the returned slice. Port of TypeScript SDK v0.2.89. ([#127](https://github.com/Flohs/claude-agent-sdk-go/issues/127))
 - `ServerToolUseBlock` and `ServerToolResultBlock` content block types and `ServerToolName` enum constants (`advisor`, `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `tool_search_tool_regex`, `tool_search_tool_bm25`). Port of Python SDK v0.1.65 / PR #836. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))

--- a/options.go
+++ b/options.go
@@ -259,4 +259,14 @@ type Options struct {
 	OutputFormat map[string]any
 	// EnableFileCheckpointing enables file change tracking for rewind support.
 	EnableFileCheckpointing bool
+	// TraceParent is the W3C `traceparent` header value to propagate to the
+	// CLI subprocess (forwarded as the `TRACEPARENT` env var). Callers using
+	// OpenTelemetry can obtain it via `propagation.TraceContext{}` or format
+	// the span context manually. When empty, the parent process environment
+	// is inherited unchanged — so an externally-set `TRACEPARENT` env var
+	// still reaches the subprocess.
+	TraceParent string
+	// TraceState is the W3C `tracestate` header value paired with TraceParent.
+	// Set together with TraceParent when forwarding a specific span.
+	TraceState string
 }

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -99,6 +99,12 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 	if t.options.EnableFileCheckpointing {
 		env = append(env, "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING=true")
 	}
+	if t.options.TraceParent != "" {
+		env = append(env, "TRACEPARENT="+t.options.TraceParent)
+	}
+	if t.options.TraceState != "" {
+		env = append(env, "TRACESTATE="+t.options.TraceState)
+	}
 	if t.cwd != "" {
 		env = append(env, "PWD="+t.cwd)
 	}


### PR DESCRIPTION
Closes #129

## Summary
- `Options.TraceParent` and `Options.TraceState` (W3C headers)
- Forwarded to the CLI subprocess as `TRACEPARENT` / `TRACESTATE`
- Unset values still flow through inherited env (OTel auto-instrumentation works out of the box)
- Port of Python SDK PR #821 + TS SDK v0.2.113

## Design notes
OpenTelemetry is **not** added as a hard dep — callers can inject the trace context manually (from `propagation.TraceContext{}`, a custom propagator, or a string they built) and the SDK forwards it.

## Test plan
- [x] Build / vet / test clean