### PR TITLE
chore: close test gaps and add examples for Skills + new hook events (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `examples/skills` demonstrating the top-level `Options.Skills` shortcut (`"all"`, named list, and mixing with explicit `AllowedTools` / `SettingSources`). ([#150](https://github.com/Flohs/claude-agent-sdk-go/issues/150))
+- `examples/hooks` extended with a `lifecycleEventsExample` that wires up the new `HookEventTaskCompleted` and `HookEventConfigChange` hooks. ([#150](https://github.com/Flohs/claude-agent-sdk-go/issues/150))
 - `Options.TraceParent` and `Options.TraceState` fields for W3C trace context propagation to the CLI subprocess (forwarded as `TRACEPARENT` / `TRACESTATE` env vars). OpenTelemetry users can inject the active span context; when unset, externally-set trace env vars still flow through the inherited environment. Port of Python SDK v0.1.60 / PR #821 and TypeScript SDK v0.2.113. ([#129](https://github.com/Flohs/claude-agent-sdk-go/issues/129))
 - `ListSubagents(sessionID, opts)` and `GetSubagentMessages(sessionID, agentID, opts)` session helpers for reading subagent transcripts from the sibling `{session_id}/subagents/` directory (supports nested layouts such as `workflows/<runId>/`). Port of Python SDK v0.1.60 / PR #825. ([#126](https://github.com/Flohs/claude-agent-sdk-go/issues/126))
 - `IncludeSystemMessages` field on `GetSessionMessagesOptions`. When set, system-subtype transcript entries (task notifications, hook events, etc.) are included in the returned slice. Port of TypeScript SDK v0.2.89. ([#127](https://github.com/Flohs/claude-agent-sdk-go/issues/127))
@@ -33,6 +35,7 @@
 ### Fixed
 
 - Assistant messages containing server-side tool blocks (`web_search`, `web_fetch`, `advisor`, etc.) previously had those blocks silently dropped by the content parser, which could produce `AssistantMessage{Content: []}` for messages that only carried server-tool blocks. The parser now emits typed `ServerToolUseBlock` / `ServerToolResultBlock` blocks. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))
+- Test helper `buildTestEnv` was out of sync with `Connect()`'s env-building logic after the trace-propagation change. The helper now mirrors the `TRACEPARENT` / `TRACESTATE` forwarding and a new `TestConnectEnv_TraceContext` covers all three cases (unset, TraceParent only, both headers). Also adds `TestParseMessage_TaskProgress_Summary` for the `Summary` field introduced with `AgentProgressSummaries`. ([#150](https://github.com/Flohs/claude-agent-sdk-go/issues/150))
 
 - `ThinkingConfigAdaptive` and `ThinkingConfigDisabled` now correctly map to `--thinking adaptive` / `--thinking disabled` CLI flags instead of incorrectly using `--max-thinking-tokens`. `ThinkingConfigEnabled` and the deprecated `MaxThinkingTokens` field continue to use `--max-thinking-tokens`. ([#99](https://github.com/Flohs/claude-agent-sdk-go/issues/99))
 

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -73,6 +73,40 @@ func addCustomInstructions(ctx context.Context, input claude.HookInput, toolUseI
 	}, nil
 }
 
+// logTaskCompletion fires when a Task-spawned sub-agent finishes.
+// Demonstrates the TaskCompleted hook event (TypeScript SDK v0.2.33, ported
+// to the Go SDK as HookEventTaskCompleted).
+func logTaskCompletion(ctx context.Context, input claude.HookInput, toolUseID string, hookCtx claude.HookContext) (claude.HookJSONOutput, error) {
+	typed, err := claude.ParseHookInput(input)
+	if err != nil {
+		return claude.HookJSONOutput{}, err
+	}
+	task, ok := typed.(*claude.TaskCompletedHookInput)
+	if !ok {
+		return claude.HookJSONOutput{}, nil
+	}
+	fmt.Printf("  [Hook] Task completed: task_id=%s agent_id=%s agent_type=%s\n",
+		task.TaskID, task.AgentID, task.AgentType)
+	return claude.HookJSONOutput{}, nil
+}
+
+// logConfigChange fires when session config (permission mode, model, …) changes.
+// Demonstrates the ConfigChange hook event (TypeScript SDK v0.2.49).
+func logConfigChange(ctx context.Context, input claude.HookInput, toolUseID string, hookCtx claude.HookContext) (claude.HookJSONOutput, error) {
+	typed, err := claude.ParseHookInput(input)
+	if err != nil {
+		return claude.HookJSONOutput{}, err
+	}
+	cfg, ok := typed.(*claude.ConfigChangeHookInput)
+	if !ok {
+		return claude.HookJSONOutput{}, nil
+	}
+	for k, v := range cfg.Changes {
+		fmt.Printf("  [Hook] Config change: %s -> %v\n", k, v)
+	}
+	return claude.HookJSONOutput{}, nil
+}
+
 // reviewToolOutput provides feedback after tool execution.
 func reviewToolOutput(ctx context.Context, input claude.HookInput, toolUseID string, hookCtx claude.HookContext) (claude.HookJSONOutput, error) {
 	toolResponse := fmt.Sprintf("%v", input["tool_response"])
@@ -160,6 +194,48 @@ func userPromptSubmitExample(ctx context.Context) {
 	fmt.Println()
 }
 
+// lifecycleEventsExample wires up TaskCompleted and ConfigChange hooks so
+// the user sees that the new hook events in the Go SDK are end-to-end usable.
+// These fire when Claude spawns a sub-agent via the Task tool or when the
+// session's runtime config changes (e.g. via Client.SetPermissionMode).
+func lifecycleEventsExample(ctx context.Context) {
+	fmt.Println("=== Lifecycle Events: TaskCompleted + ConfigChange ===")
+	fmt.Println("TaskCompleted fires when a Task-spawned sub-agent finishes.")
+	fmt.Println("ConfigChange fires on runtime config transitions.")
+
+	client := claude.NewClient(&claude.Options{
+		AllowedTools: []string{"Task"},
+		Hooks: map[claude.HookEvent][]claude.HookMatcher{
+			claude.HookEventTaskCompleted: {
+				{Hooks: []claude.HookCallback{logTaskCompletion}},
+			},
+			claude.HookEventConfigChange: {
+				{Hooks: []claude.HookCallback{logConfigChange}},
+			},
+		},
+	})
+
+	if err := client.Connect(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = client.Close() }()
+
+	// Trigger a ConfigChange by switching the permission mode mid-session.
+	if err := client.SetPermissionMode(ctx, string(claude.PermissionModeAcceptEdits)); err != nil {
+		log.Println("SetPermissionMode error:", err)
+	}
+
+	// Ask Claude to spawn a Task so TaskCompleted has a chance to fire.
+	fmt.Println("User: Using the Task tool, spawn a tiny general-purpose subagent that says hello.")
+	if err := client.SendQuery(ctx, "Using the Task tool, spawn a tiny general-purpose subagent that says hello and returns."); err != nil {
+		log.Fatal(err)
+	}
+	for msg := range client.ReceiveResponse(ctx) {
+		displayMessage(msg)
+	}
+	fmt.Println()
+}
+
 func postToolUseExample(ctx context.Context) {
 	fmt.Println("=== PostToolUse Example ===")
 	fmt.Println("Shows how PostToolUse can provide feedback.")
@@ -196,4 +272,6 @@ func main() {
 	userPromptSubmitExample(ctx)
 	fmt.Println(strings.Repeat("-", 50))
 	postToolUseExample(ctx)
+	fmt.Println(strings.Repeat("-", 50))
+	lifecycleEventsExample(ctx)
 }

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -1,0 +1,110 @@
+// Skills example demonstrating the top-level Options.Skills shortcut.
+//
+// Without Skills, enabling skills requires two coordinated options:
+//   - AllowedTools must contain `Skill` (or `Skill(name)` patterns for
+//     specific skills), otherwise the CLI rejects skill invocations.
+//   - SettingSources must include `user` and/or `project` so the CLI can
+//     discover the skill definitions from disk.
+//
+// Options.Skills wires both automatically. Pass the string "all" to enable
+// every discovered skill, or a []string for named skills. Explicit
+// SettingSources or AllowedTools values supplied by the caller are
+// preserved and take precedence.
+//
+// Usage:
+//
+//	go run ./examples/skills
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	claude "github.com/Flohs/claude-agent-sdk-go"
+)
+
+func displayMessage(msg claude.Message) {
+	switch m := msg.(type) {
+	case *claude.AssistantMessage:
+		for _, block := range m.Content {
+			if tb, ok := block.(claude.TextBlock); ok {
+				fmt.Println("Claude:", tb.Text)
+			}
+		}
+	case *claude.ResultMessage:
+		fmt.Println("Result ended")
+	}
+}
+
+// allSkills enables every skill discovered under the user's and the
+// project's setting sources.
+func allSkills(ctx context.Context) {
+	fmt.Println("=== Skills: \"all\" ===")
+	fmt.Println("Enables every discovered skill. SettingSources defaults to [user, project].")
+
+	maxTurns := 1
+	messages, errs := claude.Query(ctx, "What skills are available in this session?", &claude.Options{
+		Skills:   "all",
+		MaxTurns: &maxTurns,
+	})
+
+	for msg := range messages {
+		displayMessage(msg)
+	}
+	for err := range errs {
+		log.Println("Error:", err)
+	}
+	fmt.Println()
+}
+
+// namedSkills enables only the skills the caller lists explicitly.
+func namedSkills(ctx context.Context) {
+	fmt.Println("=== Skills: [\"pdf-tools\", \"image-tools\"] ===")
+	fmt.Println("Only the listed skills are auto-injected as Skill(name) patterns.")
+
+	maxTurns := 1
+	messages, errs := claude.Query(ctx, "List which of the pdf-tools or image-tools skills you can invoke.", &claude.Options{
+		Skills:   []string{"pdf-tools", "image-tools"},
+		MaxTurns: &maxTurns,
+	})
+
+	for msg := range messages {
+		displayMessage(msg)
+	}
+	for err := range errs {
+		log.Println("Error:", err)
+	}
+	fmt.Println()
+}
+
+// skillsWithExtraTools mixes Options.Skills with additional allowed tools
+// and an explicit SettingSources override.
+func skillsWithExtraTools(ctx context.Context) {
+	fmt.Println("=== Skills + explicit AllowedTools + SettingSources ===")
+	fmt.Println("User-supplied AllowedTools and SettingSources are preserved; Skill entries are merged in.")
+
+	maxTurns := 1
+	messages, errs := claude.Query(ctx, "Read README.md, then list any available skills.", &claude.Options{
+		Skills:         "all",
+		AllowedTools:   []string{"Read"}, // Skill gets merged alongside Read
+		SettingSources: []claude.SettingSource{claude.SettingSourceProject},
+		MaxTurns:       &maxTurns,
+	})
+
+	for msg := range messages {
+		displayMessage(msg)
+	}
+	for err := range errs {
+		log.Println("Error:", err)
+	}
+	fmt.Println()
+}
+
+func main() {
+	ctx := context.Background()
+
+	allSkills(ctx)
+	namedSkills(ctx)
+	skillsWithExtraTools(ctx)
+}

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -366,6 +366,61 @@ func TestParseMessage_TaskStarted(t *testing.T) {
 	}
 }
 
+func TestParseMessage_TaskProgress_Summary(t *testing.T) {
+	data := map[string]any{
+		"type":        "system",
+		"subtype":     "task_progress",
+		"task_id":     "t1",
+		"description": "Reading files",
+		"usage": map[string]any{
+			"total_tokens": float64(1234),
+			"tool_uses":    float64(5),
+			"duration_ms":  float64(4200),
+		},
+		"uuid":           "u1",
+		"session_id":     "s1",
+		"last_tool_name": "Read",
+		"summary":        "Inspecting the transport layer to diagnose the stdin close race.",
+	}
+
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	progress, ok := msg.(*TaskProgressMessage)
+	if !ok {
+		t.Fatalf("expected *TaskProgressMessage, got %T", msg)
+	}
+	if progress.Summary != "Inspecting the transport layer to diagnose the stdin close race." {
+		t.Errorf("Summary = %q, want the full summary", progress.Summary)
+	}
+	if progress.LastToolName != "Read" {
+		t.Errorf("LastToolName = %q, want Read", progress.LastToolName)
+	}
+	if progress.Usage.TotalTokens != 1234 {
+		t.Errorf("Usage.TotalTokens = %d, want 1234", progress.Usage.TotalTokens)
+	}
+}
+
+func TestParseMessage_TaskProgress_SummaryAbsent(t *testing.T) {
+	data := map[string]any{
+		"type":       "system",
+		"subtype":    "task_progress",
+		"task_id":    "t1",
+		"uuid":       "u1",
+		"session_id": "s1",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	progress := msg.(*TaskProgressMessage)
+	if progress.Summary != "" {
+		t.Errorf("Summary = %q, want empty when absent", progress.Summary)
+	}
+}
+
 func TestParseMessage_ResultMessage(t *testing.T) {
 	cost := 0.05
 	data := map[string]any{

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -263,6 +263,12 @@ func buildTestEnv(opts *Options) []string {
 	if opts.EnableFileCheckpointing {
 		env = append(env, "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING=true")
 	}
+	if opts.TraceParent != "" {
+		env = append(env, "TRACEPARENT="+opts.TraceParent)
+	}
+	if opts.TraceState != "" {
+		env = append(env, "TRACESTATE="+opts.TraceState)
+	}
 	return env
 }
 
@@ -275,6 +281,42 @@ func assertEnvNotContainsKey(t *testing.T, env []string, key string) {
 			return
 		}
 	}
+}
+
+func assertEnvContains(t *testing.T, env []string, key, value string) {
+	t.Helper()
+	target := key + "=" + value
+	for _, e := range env {
+		if e == target {
+			return
+		}
+	}
+	t.Errorf("env missing %s", target)
+}
+
+func TestConnectEnv_TraceContext(t *testing.T) {
+	t.Run("unset omits both env vars", func(t *testing.T) {
+		env := buildTestEnv(&Options{})
+		assertEnvNotContainsKey(t, env, "TRACEPARENT")
+		assertEnvNotContainsKey(t, env, "TRACESTATE")
+	})
+
+	t.Run("TraceParent only", func(t *testing.T) {
+		env := buildTestEnv(&Options{
+			TraceParent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		})
+		assertEnvContains(t, env, "TRACEPARENT", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+		assertEnvNotContainsKey(t, env, "TRACESTATE")
+	})
+
+	t.Run("TraceParent and TraceState", func(t *testing.T) {
+		env := buildTestEnv(&Options{
+			TraceParent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			TraceState:  "vendor1=value1,vendor2=value2",
+		})
+		assertEnvContains(t, env, "TRACEPARENT", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+		assertEnvContains(t, env, "TRACESTATE", "vendor1=value1,vendor2=value2")
+	})
 }
 
 func TestCompareVersions(t *testing.T) {


### PR DESCRIPTION
Closes #150

## Summary

### Test gaps closed
- Synced `buildTestEnv` helper with the production `Connect()` env-building path. The helper now forwards `TRACEPARENT` / `TRACESTATE` so `#129` is actually covered.
- New `TestConnectEnv_TraceContext` with 3 sub-cases: unset omits both vars, `TraceParent` only, both headers together.
- New `TestParseMessage_TaskProgress_Summary` + `TaskProgress_SummaryAbsent` covering the `Summary` field added with `AgentProgressSummaries` (#115).

### Examples
- **New `examples/skills/`** demonstrating the top-level `Options.Skills` shortcut: `"all"`, named list, and mixing with explicit `AllowedTools` / `SettingSources`.
- **Extended `examples/hooks/`** with `lifecycleEventsExample` that wires up `HookEventTaskCompleted` and `HookEventConfigChange` so users see how to consume the new hook events end-to-end.

## Out of scope
No tests added for the control-request client methods (`ReloadPlugins`, `EnableMcpChannel`, `SupportedAgents`, `SupportedCommands`, `PromptSuggestion`, `StopAsyncMessage`, `SeedReadState`). These follow the existing no-mock pattern used by `ReconnectMcpServer`, `ToggleMcpServer`, `StopTask`, etc. Adding a mock-transport harness is a separate, larger change.

## Test plan
- [x] `go build ./...` clean (examples included)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean
- [x] New tests pass in isolation