### PR TITLE
feat: SessionStore types + InMemorySessionStore (Sub A, #152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `SessionStore` interface + 4 optional extension interfaces (`SessionStoreLister`, `SessionStoreSummarizer`, `SessionStoreDeleter`, `SessionStoreSubkeys`), `InMemorySessionStore` reference adapter, and foundational types/helpers (`SessionKey`, `SessionStoreEntry`, `SessionStoreListEntry`, `SessionSummaryEntry`, `SessionListSubkeysKey`, `ProjectKeyForDirectory`, `FilePathToSessionKey`, `FoldSessionSummary`). Foundation for SessionStore support (umbrella #110). Port of Python SDK v0.1.64 (PR #837). No runtime effect yet — wiring lands in Sub B. ([#152](https://github.com/Flohs/claude-agent-sdk-go/issues/152))
 - `examples/skills` demonstrating the top-level `Options.Skills` shortcut (`"all"`, named list, and mixing with explicit `AllowedTools` / `SettingSources`). ([#150](https://github.com/Flohs/claude-agent-sdk-go/issues/150))
 - `examples/hooks` extended with a `lifecycleEventsExample` that wires up the new `HookEventTaskCompleted` and `HookEventConfigChange` hooks. ([#150](https://github.com/Flohs/claude-agent-sdk-go/issues/150))
 - `Options.TraceParent` and `Options.TraceState` fields for W3C trace context propagation to the CLI subprocess (forwarded as `TRACEPARENT` / `TRACESTATE` env vars). OpenTelemetry users can inject the active span context; when unset, externally-set trace env vars still flow through the inherited environment. Port of Python SDK v0.1.60 / PR #821 and TypeScript SDK v0.2.113. ([#129](https://github.com/Flohs/claude-agent-sdk-go/issues/129))

--- a/session_store.go
+++ b/session_store.go
@@ -1,0 +1,585 @@
+package claude
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SessionStore is the required interface for every session-store adapter.
+//
+// Adapters persist one [SessionStoreEntry] per JSONL line of the transcript
+// identified by a [SessionKey]. Append must be additive (never overwrite
+// prior entries for the same key) and Load must return the exact sequence
+// that Append produced, in insertion order.
+//
+// Load returns (nil, nil) when the key has no entries — that is not an
+// error. Errors are reserved for genuine I/O or corruption failures.
+//
+// Adapters may additionally implement one or more of the optional extension
+// interfaces ([SessionStoreLister], [SessionStoreSummarizer],
+// [SessionStoreDeleter], [SessionStoreSubkeys]); the SDK probes them via
+// type assertion.
+//
+// Implementations must be safe for concurrent use.
+type SessionStore interface {
+	// Append adds entries to the transcript for key in insertion order.
+	Append(ctx context.Context, key SessionKey, entries []SessionStoreEntry) error
+	// Load returns every entry previously appended for key, in order.
+	// Returns (nil, nil) when the key is absent.
+	Load(ctx context.Context, key SessionKey) ([]SessionStoreEntry, error)
+}
+
+// SessionStoreLister is an optional [SessionStore] extension that lists
+// the main-transcript sessions within a project. Subagent and other
+// sub-streams (keys with a non-empty Subpath) must be excluded from the
+// result.
+type SessionStoreLister interface {
+	ListSessions(ctx context.Context, projectKey string) ([]SessionStoreListEntry, error)
+}
+
+// SessionStoreSummarizer is an optional [SessionStore] extension that
+// returns per-session summary sidecars maintained incrementally via
+// [FoldSessionSummary]. Consumers can hydrate a full session listing
+// without issuing per-session Load calls.
+type SessionStoreSummarizer interface {
+	ListSessionSummaries(ctx context.Context, projectKey string) ([]SessionSummaryEntry, error)
+}
+
+// SessionStoreDeleter is an optional [SessionStore] extension that removes
+// a stored key. When the deleted key has no Subpath (i.e. is a main
+// transcript), the adapter must also cascade-delete any sibling subkeys
+// (subagent transcripts, etc.) so they are not orphaned. A targeted delete
+// with an explicit Subpath removes only that one entry.
+type SessionStoreDeleter interface {
+	Delete(ctx context.Context, key SessionKey) error
+}
+
+// SessionStoreSubkeys is an optional [SessionStore] extension that lists
+// the subkeys (Subpath values) associated with a given main session. The
+// return slice contains the Subpath portion only, stripped of the leading
+// "<project_key>/<session_id>/" prefix.
+type SessionStoreSubkeys interface {
+	ListSubkeys(ctx context.Context, key SessionListSubkeysKey) ([]string, error)
+}
+
+// ProjectKeyForDirectory derives the [SessionStore] project_key for a
+// directory using the same realpath + NFC normalization + hashed
+// sanitization the CLI uses for project directory names, so keys match
+// between local-disk transcripts and store-mirrored transcripts even on
+// filesystems that decompose Unicode (e.g. macOS HFS+).
+//
+// An empty dir is treated as the current working directory.
+func ProjectKeyForDirectory(dir string) string {
+	if dir == "" {
+		dir = "."
+	}
+	return sanitizePath(canonicalizePath(dir))
+}
+
+// FilePathToSessionKey parses an absolute transcript file path rooted under
+// projectsDir into its [SessionKey].
+//
+// Two layouts are recognized:
+//
+//   - Main transcript: "<projectsDir>/<project_key>/<session_id>.jsonl"
+//     → {ProjectKey, SessionID, Subpath: ""}
+//   - Subagent transcript: "<projectsDir>/<project_key>/<session_id>/subagents/agent-<id>.jsonl"
+//     (with any depth under subagents/, e.g. "workflows/<runId>/agent-<id>.jsonl")
+//     → {ProjectKey, SessionID, Subpath: "subagents/.../agent-<id>"}
+//
+// Subpath is always "/"-joined regardless of the host OS separator so keys
+// are portable across platforms. The ".jsonl" suffix is stripped from the
+// final Subpath component.
+//
+// Returns (SessionKey{}, false) when absPath is not under projectsDir or
+// the path does not match either recognized shape.
+func FilePathToSessionKey(absPath, projectsDir string) (SessionKey, bool) {
+	rel, err := filepath.Rel(projectsDir, absPath)
+	if err != nil {
+		return SessionKey{}, false
+	}
+	if rel == "" || rel == "." {
+		return SessionKey{}, false
+	}
+	// filepath.Rel happily returns ".." for paths outside the base.
+	if strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+		return SessionKey{}, false
+	}
+
+	parts := splitPathAll(rel)
+	if len(parts) < 2 {
+		return SessionKey{}, false
+	}
+
+	projectKey := parts[0]
+	second := parts[1]
+
+	// Main transcript: <project_key>/<session_id>.jsonl
+	if len(parts) == 2 && strings.HasSuffix(second, ".jsonl") {
+		return SessionKey{
+			ProjectKey: projectKey,
+			SessionID:  strings.TrimSuffix(second, ".jsonl"),
+		}, true
+	}
+
+	// Subagent (or other) sub-stream: <project_key>/<session_id>/<...>/<name>.jsonl
+	if len(parts) >= 4 {
+		subParts := make([]string, len(parts)-2)
+		copy(subParts, parts[2:])
+		last := subParts[len(subParts)-1]
+		if strings.HasSuffix(last, ".jsonl") {
+			subParts[len(subParts)-1] = strings.TrimSuffix(last, ".jsonl")
+		}
+		return SessionKey{
+			ProjectKey: projectKey,
+			SessionID:  second,
+			Subpath:    strings.Join(subParts, "/"),
+		}, true
+	}
+
+	return SessionKey{}, false
+}
+
+// splitPathAll splits rel into its path components using the host OS
+// separator. It is a small wrapper around filepath.SplitList semantics that
+// handles both "/" and "\\" separators uniformly.
+func splitPathAll(rel string) []string {
+	// filepath.ToSlash collapses the OS separator to "/". That lets us use
+	// strings.Split without caring whether we're on Windows or POSIX.
+	slashed := filepath.ToSlash(rel)
+	if slashed == "" {
+		return nil
+	}
+	return strings.Split(slashed, "/")
+}
+
+// FoldSessionSummary folds a batch of newly-appended entries into a
+// running [SessionSummaryEntry] for key.
+//
+// Adapters should call this from inside Append to maintain a per-session
+// summary sidecar so [SessionStoreSummarizer.ListSessionSummaries] can
+// return results without re-reading the full transcript. prev is the
+// previous summary for the same session (or nil for the first append for a
+// new session).
+//
+// IMPORTANT: only call this for keys where Subpath == "". Subagent
+// transcripts must not contribute to the main session's summary — the
+// adapter is responsible for skipping those keys.
+//
+// Each call processes exactly the entries passed in: adapters should pass
+// only the newly-appended slice so the fold stays append-incremental (no
+// re-reads). All derived state lives in the opaque Data map; adapters
+// persist the returned summary verbatim.
+//
+// Mtime is NOT set by the fold — it is the sidecar's storage write time
+// and must be stamped by the adapter after persisting so it shares a clock
+// with the mtime returned by [SessionStoreLister.ListSessions]. For a new
+// session (prev == nil) the returned summary has Mtime == 0 as a
+// placeholder.
+func FoldSessionSummary(prev *SessionSummaryEntry, key SessionKey, entries []SessionStoreEntry) *SessionSummaryEntry {
+	var summary SessionSummaryEntry
+	if prev != nil {
+		summary = SessionSummaryEntry{
+			SessionID: prev.SessionID,
+			Mtime:     prev.Mtime,
+			Data:      cloneStringAnyMap(prev.Data),
+		}
+	} else {
+		summary = SessionSummaryEntry{
+			SessionID: key.SessionID,
+			Mtime:     0,
+			Data:      map[string]any{},
+		}
+	}
+	data := summary.Data
+
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		ms := isoToEpochMs(entry["timestamp"])
+
+		if _, ok := data["is_sidechain"]; !ok {
+			isSC, _ := entry["isSidechain"].(bool)
+			data["is_sidechain"] = isSC
+		}
+		if _, ok := data["created_at"]; !ok && ms != nil {
+			data["created_at"] = *ms
+		}
+		if _, ok := data["cwd"]; !ok {
+			if cwd, ok := entry["cwd"].(string); ok && cwd != "" {
+				data["cwd"] = cwd
+			}
+		}
+
+		foldFirstPrompt(data, entry)
+
+		for src, dst := range lastWinsFields {
+			if val, ok := entry[src].(string); ok {
+				data[dst] = val
+			}
+		}
+
+		if t, _ := entry["type"].(string); t == "tag" {
+			if tagVal, ok := entry["tag"].(string); ok && tagVal != "" {
+				data["tag"] = tagVal
+			} else {
+				delete(data, "tag")
+			}
+		}
+	}
+
+	return &summary
+}
+
+// lastWinsFields maps JSONL entry keys to [SessionSummaryEntry.Data] keys
+// for string fields where each appended entry overwrites the previous value
+// (last-wins semantics). Matches the Python fold.
+var lastWinsFields = map[string]string{
+	"customTitle": "custom_title",
+	"aiTitle":     "ai_title",
+	"lastPrompt":  "last_prompt",
+	"summary":     "summary_hint",
+	"gitBranch":   "git_branch",
+}
+
+// isoToEpochMs parses an ISO-8601 timestamp string into Unix epoch
+// milliseconds, or returns nil if the value is not a parseable string.
+func isoToEpochMs(v any) *int64 {
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05.000-07:00",
+		"2006-01-02T15:04:05-07:00",
+		time.RFC3339Nano,
+		time.RFC3339,
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			ms := t.UnixMilli()
+			return &ms
+		}
+	}
+	return nil
+}
+
+// foldFirstPrompt mirrors Python's _fold_first_prompt: sets
+// data["first_prompt"] + data["first_prompt_locked"] on a real user
+// message, or stashes data["command_fallback"] for slash-command entries.
+// It skips tool_result, isMeta, isCompactSummary, and auto-generated
+// patterns.
+func foldFirstPrompt(data map[string]any, entry map[string]any) {
+	if locked, _ := data["first_prompt_locked"].(bool); locked {
+		return
+	}
+	if t, _ := entry["type"].(string); t != "user" {
+		return
+	}
+	if m, _ := entry["isMeta"].(bool); m {
+		return
+	}
+	if c, _ := entry["isCompactSummary"].(bool); c {
+		return
+	}
+	message, ok := entry["message"].(map[string]any)
+	if !ok {
+		return
+	}
+	// Skip tool_result-carrying user messages.
+	if content, ok := message["content"].([]any); ok {
+		for _, block := range content {
+			if bm, ok := block.(map[string]any); ok {
+				if bm["type"] == "tool_result" {
+					return
+				}
+			}
+		}
+	}
+
+	for _, raw := range entryTextBlocks(message) {
+		result := strings.ReplaceAll(raw, "\n", " ")
+		result = strings.TrimSpace(result)
+		if result == "" {
+			continue
+		}
+		if m := commandNameRE.FindStringSubmatch(result); m != nil {
+			if _, already := data["command_fallback"]; !already {
+				data["command_fallback"] = m[1]
+			}
+			continue
+		}
+		if skipFirstPromptPattern.MatchString(result) {
+			continue
+		}
+		runes := []rune(result)
+		if len(runes) > 200 {
+			result = strings.TrimRightFunc(string(runes[:200]), func(r rune) bool {
+				return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+			}) + "…"
+		}
+		data["first_prompt"] = result
+		data["first_prompt_locked"] = true
+		return
+	}
+}
+
+// entryTextBlocks returns the text strings inside a user entry's
+// message.content — either the raw string content or the text blocks from
+// a content array.
+func entryTextBlocks(message map[string]any) []string {
+	content := message["content"]
+	var texts []string
+	switch v := content.(type) {
+	case string:
+		texts = append(texts, v)
+	case []any:
+		for _, block := range v {
+			if bm, ok := block.(map[string]any); ok {
+				if bm["type"] == "text" {
+					if t, ok := bm["text"].(string); ok {
+						texts = append(texts, t)
+					}
+				}
+			}
+		}
+	}
+	return texts
+}
+
+func cloneStringAnyMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// InMemorySessionStore is the reference [SessionStore] implementation.
+//
+// It stores entries in memory keyed by a composite
+// "<project_key>/<session_id>[/<subpath>]" string and implements all four
+// optional extension interfaces ([SessionStoreLister],
+// [SessionStoreSummarizer], [SessionStoreDeleter], [SessionStoreSubkeys]).
+//
+// Data is lost when the process exits — this is intended for tests and
+// development, not production workloads. Safe for concurrent use.
+type InMemorySessionStore struct {
+	mu        sync.RWMutex
+	store     map[string][]SessionStoreEntry
+	mtimes    map[string]int64
+	summaries map[summaryKey]SessionSummaryEntry
+	lastMtime int64
+	nowMilli  func() int64 // override-able for tests; nil → time.Now
+}
+
+type summaryKey struct {
+	projectKey string
+	sessionID  string
+}
+
+// NewInMemorySessionStore returns a fresh [InMemorySessionStore].
+func NewInMemorySessionStore() *InMemorySessionStore {
+	return &InMemorySessionStore{
+		store:     map[string][]SessionStoreEntry{},
+		mtimes:    map[string]int64{},
+		summaries: map[summaryKey]SessionSummaryEntry{},
+	}
+}
+
+// keyToString produces the composite map key used internally. Matches the
+// Python reference.
+func keyToString(key SessionKey) string {
+	if key.Subpath == "" {
+		return key.ProjectKey + "/" + key.SessionID
+	}
+	return key.ProjectKey + "/" + key.SessionID + "/" + key.Subpath
+}
+
+// nextMtime returns a strictly monotonically increasing Unix-epoch-ms
+// timestamp. Callers must hold s.mu for writing.
+func (s *InMemorySessionStore) nextMtime() int64 {
+	var now int64
+	if s.nowMilli != nil {
+		now = s.nowMilli()
+	} else {
+		now = time.Now().UnixMilli()
+	}
+	if now <= s.lastMtime {
+		now = s.lastMtime + 1
+	}
+	s.lastMtime = now
+	return now
+}
+
+// Append satisfies [SessionStore].
+func (s *InMemorySessionStore) Append(ctx context.Context, key SessionKey, entries []SessionStoreEntry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	k := keyToString(key)
+	// Copy entries defensively so caller mutations after Append don't
+	// corrupt the store.
+	cp := make([]SessionStoreEntry, len(entries))
+	copy(cp, entries)
+	s.store[k] = append(s.store[k], cp...)
+
+	now := s.nextMtime()
+	s.mtimes[k] = now
+
+	// Only main transcripts contribute to the per-session summary sidecar.
+	if key.Subpath == "" {
+		sk := summaryKey{projectKey: key.ProjectKey, sessionID: key.SessionID}
+		var prev *SessionSummaryEntry
+		if existing, ok := s.summaries[sk]; ok {
+			prevCopy := existing
+			prev = &prevCopy
+		}
+		folded := FoldSessionSummary(prev, key, cp)
+		folded.Mtime = now
+		s.summaries[sk] = *folded
+	}
+	return nil
+}
+
+// Load satisfies [SessionStore].
+func (s *InMemorySessionStore) Load(ctx context.Context, key SessionKey) ([]SessionStoreEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, ok := s.store[keyToString(key)]
+	if !ok {
+		return nil, nil
+	}
+	out := make([]SessionStoreEntry, len(entries))
+	copy(out, entries)
+	return out, nil
+}
+
+// ListSessions satisfies [SessionStoreLister]. Main transcripts only —
+// subagent and other sub-streams (keys with a non-empty Subpath) are
+// excluded. Results are ordered by Mtime descending.
+func (s *InMemorySessionStore) ListSessions(ctx context.Context, projectKey string) ([]SessionStoreListEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	prefix := projectKey + "/"
+	var results []SessionStoreListEntry
+	for k := range s.store {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		rest := k[len(prefix):]
+		// Main transcripts have exactly one component after the project
+		// prefix — no further "/".
+		if strings.Contains(rest, "/") {
+			continue
+		}
+		results = append(results, SessionStoreListEntry{
+			SessionID: rest,
+			Mtime:     s.mtimes[k],
+		})
+	}
+
+	// Order by mtime descending to match the convention established by
+	// the on-disk ListSessions and the fast-path staleness check.
+	sortByMtimeDesc(results)
+	return results, nil
+}
+
+// sortByMtimeDesc does a small in-place insertion sort on results. The
+// result set is tiny in practice (bounded by number of sessions in a
+// single project), so this keeps the dependency surface minimal.
+func sortByMtimeDesc(results []SessionStoreListEntry) {
+	for i := 1; i < len(results); i++ {
+		j := i
+		for j > 0 && results[j].Mtime > results[j-1].Mtime {
+			results[j], results[j-1] = results[j-1], results[j]
+			j--
+		}
+	}
+}
+
+// ListSessionSummaries satisfies [SessionStoreSummarizer].
+func (s *InMemorySessionStore) ListSessionSummaries(ctx context.Context, projectKey string) ([]SessionSummaryEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []SessionSummaryEntry
+	for sk, summary := range s.summaries {
+		if sk.projectKey != projectKey {
+			continue
+		}
+		// Defensive copy: hand out a fresh Data map so callers can't
+		// mutate shared state.
+		cp := summary
+		cp.Data = cloneStringAnyMap(summary.Data)
+		out = append(out, cp)
+	}
+	return out, nil
+}
+
+// Delete satisfies [SessionStoreDeleter]. Deleting a main-transcript key
+// (Subpath == "") cascades to the session's sibling subkeys (subagent
+// transcripts and other sub-streams) and the per-session summary sidecar.
+// A targeted delete with an explicit Subpath removes only that one entry.
+func (s *InMemorySessionStore) Delete(ctx context.Context, key SessionKey) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	k := keyToString(key)
+	delete(s.store, k)
+	delete(s.mtimes, k)
+
+	if key.Subpath == "" {
+		delete(s.summaries, summaryKey{projectKey: key.ProjectKey, sessionID: key.SessionID})
+		prefix := key.ProjectKey + "/" + key.SessionID + "/"
+		for storeKey := range s.store {
+			if strings.HasPrefix(storeKey, prefix) {
+				delete(s.store, storeKey)
+				delete(s.mtimes, storeKey)
+			}
+		}
+	}
+	return nil
+}
+
+// ListSubkeys satisfies [SessionStoreSubkeys]. Returns only the Subpath
+// portion of each matching stored key (i.e. the part after
+// "<project_key>/<session_id>/").
+func (s *InMemorySessionStore) ListSubkeys(ctx context.Context, key SessionListSubkeysKey) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	prefix := key.ProjectKey + "/" + key.SessionID + "/"
+	var out []string
+	for k := range s.store {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, k[len(prefix):])
+		}
+	}
+	return out, nil
+}

--- a/session_store_test.go
+++ b/session_store_test.go
@@ -1,0 +1,612 @@
+package claude
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// entry is a tiny helper for building SessionStoreEntry literals in tests.
+func entry(fields map[string]any) SessionStoreEntry {
+	return SessionStoreEntry(fields)
+}
+
+func TestInMemorySessionStore_AppendLoadRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	key := SessionKey{ProjectKey: "proj", SessionID: "sess-1"}
+	entries := []SessionStoreEntry{
+		entry(map[string]any{"type": "user", "message": map[string]any{"content": "hello"}}),
+		entry(map[string]any{"type": "assistant", "message": map[string]any{"content": "hi"}}),
+	}
+
+	if err := s.Append(ctx, key, entries); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	got, err := s.Load(ctx, key)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+	if got[0]["type"] != "user" || got[1]["type"] != "assistant" {
+		t.Errorf("entries out of order: %+v", got)
+	}
+
+	// Appending more entries extends the list.
+	more := []SessionStoreEntry{
+		entry(map[string]any{"type": "user", "message": map[string]any{"content": "again"}}),
+	}
+	if err := s.Append(ctx, key, more); err != nil {
+		t.Fatalf("Append 2: %v", err)
+	}
+	got, _ = s.Load(ctx, key)
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries after second append, got %d", len(got))
+	}
+}
+
+func TestInMemorySessionStore_LoadMissingKeyReturnsNilNil(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	got, err := s.Load(ctx, SessionKey{ProjectKey: "p", SessionID: "missing"})
+	if err != nil {
+		t.Fatalf("Load on missing key returned error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Load on missing key should return nil slice, got %+v", got)
+	}
+}
+
+func TestInMemorySessionStore_MultiKeyIsolation(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	keyX := SessionKey{ProjectKey: "p", SessionID: "x"}
+	keyY := SessionKey{ProjectKey: "p", SessionID: "y"}
+
+	_ = s.Append(ctx, keyX, []SessionStoreEntry{entry(map[string]any{"tag": "x1"})})
+	_ = s.Append(ctx, keyY, []SessionStoreEntry{entry(map[string]any{"tag": "y1"})})
+	_ = s.Append(ctx, keyX, []SessionStoreEntry{entry(map[string]any{"tag": "x2"})})
+
+	gotX, _ := s.Load(ctx, keyX)
+	gotY, _ := s.Load(ctx, keyY)
+	if len(gotX) != 2 || gotX[0]["tag"] != "x1" || gotX[1]["tag"] != "x2" {
+		t.Errorf("keyX isolation broken: %+v", gotX)
+	}
+	if len(gotY) != 1 || gotY[0]["tag"] != "y1" {
+		t.Errorf("keyY isolation broken: %+v", gotY)
+	}
+}
+
+func TestInMemorySessionStore_AppendCopiesEntries(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+	key := SessionKey{ProjectKey: "p", SessionID: "s"}
+
+	in := []SessionStoreEntry{entry(map[string]any{"k": "original"})}
+	if err := s.Append(ctx, key, in); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	// Mutate the caller slice; stored copy must be unaffected.
+	in[0] = entry(map[string]any{"k": "mutated"})
+
+	got, _ := s.Load(ctx, key)
+	if got[0]["k"] != "original" {
+		t.Errorf("store did not defensively copy entries slice: got %+v", got[0])
+	}
+}
+
+func TestInMemorySessionStore_ListSessionsOrderedByMtimeDesc(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	// Drive a deterministic clock so mtimes are predictable.
+	tick := int64(1000)
+	s.nowMilli = func() int64 {
+		tick++
+		return tick
+	}
+
+	for _, id := range []string{"a", "b", "c"} {
+		if err := s.Append(ctx, SessionKey{ProjectKey: "proj", SessionID: id},
+			[]SessionStoreEntry{entry(map[string]any{"type": "user"})}); err != nil {
+			t.Fatalf("Append %s: %v", id, err)
+		}
+	}
+
+	list, err := s.ListSessions(ctx, "proj")
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("want 3 entries, got %d", len(list))
+	}
+	if list[0].SessionID != "c" || list[1].SessionID != "b" || list[2].SessionID != "a" {
+		t.Errorf("want mtime-desc order [c,b,a], got %+v", list)
+	}
+	// Subagent subkeys must not appear in ListSessions.
+	_ = s.Append(ctx, SessionKey{ProjectKey: "proj", SessionID: "a", Subpath: "subagents/agent-x"},
+		[]SessionStoreEntry{entry(map[string]any{})})
+	list2, _ := s.ListSessions(ctx, "proj")
+	for _, e := range list2 {
+		if e.SessionID == "subagents/agent-x" {
+			t.Errorf("ListSessions leaked subkey: %+v", e)
+		}
+	}
+	if len(list2) != 3 {
+		t.Errorf("ListSessions should still report 3 main sessions, got %d", len(list2))
+	}
+}
+
+func TestInMemorySessionStore_ListSessionsFiltersByProject(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	_ = s.Append(ctx, SessionKey{ProjectKey: "p1", SessionID: "a"}, []SessionStoreEntry{entry(map[string]any{})})
+	_ = s.Append(ctx, SessionKey{ProjectKey: "p2", SessionID: "b"}, []SessionStoreEntry{entry(map[string]any{})})
+
+	p1, _ := s.ListSessions(ctx, "p1")
+	p2, _ := s.ListSessions(ctx, "p2")
+	if len(p1) != 1 || p1[0].SessionID != "a" {
+		t.Errorf("p1 listing wrong: %+v", p1)
+	}
+	if len(p2) != 1 || p2[0].SessionID != "b" {
+		t.Errorf("p2 listing wrong: %+v", p2)
+	}
+}
+
+func TestInMemorySessionStore_DeleteCascadesSubkeys(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	main := SessionKey{ProjectKey: "proj", SessionID: "sess"}
+	sub1 := SessionKey{ProjectKey: "proj", SessionID: "sess", Subpath: "subagents/agent-a"}
+	sub2 := SessionKey{ProjectKey: "proj", SessionID: "sess", Subpath: "subagents/agent-b"}
+	unrelated := SessionKey{ProjectKey: "proj", SessionID: "other"}
+
+	_ = s.Append(ctx, main, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+	_ = s.Append(ctx, sub1, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+	_ = s.Append(ctx, sub2, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+	_ = s.Append(ctx, unrelated, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+
+	if err := s.Delete(ctx, main); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if got, _ := s.Load(ctx, main); got != nil {
+		t.Errorf("main key not deleted: %+v", got)
+	}
+	if got, _ := s.Load(ctx, sub1); got != nil {
+		t.Errorf("subkey sub1 not cascade-deleted: %+v", got)
+	}
+	if got, _ := s.Load(ctx, sub2); got != nil {
+		t.Errorf("subkey sub2 not cascade-deleted: %+v", got)
+	}
+	if got, _ := s.Load(ctx, unrelated); got == nil {
+		t.Errorf("unrelated sibling session was wrongly deleted")
+	}
+
+	// Summary sidecar for the deleted session is gone.
+	summaries, _ := s.ListSessionSummaries(ctx, "proj")
+	for _, sum := range summaries {
+		if sum.SessionID == "sess" {
+			t.Errorf("summary for deleted session still present: %+v", sum)
+		}
+	}
+}
+
+func TestInMemorySessionStore_DeleteTargetedSubkeyOnly(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	main := SessionKey{ProjectKey: "proj", SessionID: "sess"}
+	sub1 := SessionKey{ProjectKey: "proj", SessionID: "sess", Subpath: "subagents/agent-a"}
+	sub2 := SessionKey{ProjectKey: "proj", SessionID: "sess", Subpath: "subagents/agent-b"}
+
+	_ = s.Append(ctx, main, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+	_ = s.Append(ctx, sub1, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+	_ = s.Append(ctx, sub2, []SessionStoreEntry{entry(map[string]any{"type": "user"})})
+
+	// Targeted delete of only sub1; main and sub2 survive.
+	if err := s.Delete(ctx, sub1); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got, _ := s.Load(ctx, sub1); got != nil {
+		t.Errorf("sub1 should be deleted, got %+v", got)
+	}
+	if got, _ := s.Load(ctx, main); got == nil {
+		t.Errorf("main key must not be cascade-deleted from a targeted subpath delete")
+	}
+	if got, _ := s.Load(ctx, sub2); got == nil {
+		t.Errorf("sub2 must not be cascade-deleted from a targeted sub1 delete")
+	}
+}
+
+func TestInMemorySessionStore_ListSubkeysFiltersBySession(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+
+	_ = s.Append(ctx, SessionKey{ProjectKey: "proj", SessionID: "sess-a", Subpath: "subagents/agent-1"},
+		[]SessionStoreEntry{entry(map[string]any{})})
+	_ = s.Append(ctx, SessionKey{ProjectKey: "proj", SessionID: "sess-a", Subpath: "subagents/agent-2"},
+		[]SessionStoreEntry{entry(map[string]any{})})
+	_ = s.Append(ctx, SessionKey{ProjectKey: "proj", SessionID: "sess-b", Subpath: "subagents/agent-3"},
+		[]SessionStoreEntry{entry(map[string]any{})})
+
+	subs, err := s.ListSubkeys(ctx, SessionListSubkeysKey{ProjectKey: "proj", SessionID: "sess-a"})
+	if err != nil {
+		t.Fatalf("ListSubkeys: %v", err)
+	}
+	sort.Strings(subs)
+	want := []string{"subagents/agent-1", "subagents/agent-2"}
+	if len(subs) != len(want) || subs[0] != want[0] || subs[1] != want[1] {
+		t.Errorf("want %+v, got %+v", want, subs)
+	}
+}
+
+func TestInMemorySessionStore_ConcurrentAppendsRaceSafe(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+	key := SessionKey{ProjectKey: "proj", SessionID: "sess"}
+
+	const N = 10
+	const perGoroutine = 20
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				_ = s.Append(ctx, key, []SessionStoreEntry{
+					entry(map[string]any{"g": i, "j": j}),
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := s.Load(ctx, key)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got) != N*perGoroutine {
+		t.Errorf("want %d total entries, got %d", N*perGoroutine, len(got))
+	}
+}
+
+func TestInMemorySessionStore_InterfaceConformance(t *testing.T) {
+	var s interface{} = NewInMemorySessionStore()
+
+	if _, ok := s.(SessionStore); !ok {
+		t.Error("InMemorySessionStore must implement SessionStore")
+	}
+	if _, ok := s.(SessionStoreLister); !ok {
+		t.Error("InMemorySessionStore must implement SessionStoreLister")
+	}
+	if _, ok := s.(SessionStoreSummarizer); !ok {
+		t.Error("InMemorySessionStore must implement SessionStoreSummarizer")
+	}
+	if _, ok := s.(SessionStoreDeleter); !ok {
+		t.Error("InMemorySessionStore must implement SessionStoreDeleter")
+	}
+	if _, ok := s.(SessionStoreSubkeys); !ok {
+		t.Error("InMemorySessionStore must implement SessionStoreSubkeys")
+	}
+}
+
+func TestInMemorySessionStore_ContextCancellation(t *testing.T) {
+	s := NewInMemorySessionStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := s.Append(ctx, SessionKey{ProjectKey: "p", SessionID: "s"}, nil); err == nil {
+		t.Error("Append should honor cancelled context")
+	}
+	if _, err := s.Load(ctx, SessionKey{ProjectKey: "p", SessionID: "s"}); err == nil {
+		t.Error("Load should honor cancelled context")
+	}
+}
+
+func TestProjectKeyForDirectory(t *testing.T) {
+	// Matches the existing sanitizePath contract (see sessions_test.go).
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"abc123", "abc123"},
+		{"/path/with spaces/x!y", "-path-with-spaces-x-y"},
+	}
+	for _, tt := range tests {
+		got := ProjectKeyForDirectory(tt.in)
+		if got != tt.want {
+			t.Errorf("ProjectKeyForDirectory(%q) = %q, want (canonicalized form of) %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestProjectKeyForDirectory_EmptyDefaultsToCwd(t *testing.T) {
+	// Empty string should be treated as "." — should not panic and should
+	// produce a non-empty sanitized key.
+	if got := ProjectKeyForDirectory(""); got == "" {
+		t.Error("ProjectKeyForDirectory(\"\") returned empty string")
+	}
+}
+
+func TestFilePathToSessionKey_MainTranscript(t *testing.T) {
+	projectsDir := filepath.Join("home", "user", ".claude", "projects")
+	abs := filepath.Join(projectsDir, "-home-user-project", "550e8400-e29b-41d4-a716-446655440000.jsonl")
+
+	key, ok := FilePathToSessionKey(abs, projectsDir)
+	if !ok {
+		t.Fatalf("FilePathToSessionKey returned ok=false for %s", abs)
+	}
+	if key.ProjectKey != "-home-user-project" {
+		t.Errorf("ProjectKey = %q, want %q", key.ProjectKey, "-home-user-project")
+	}
+	if key.SessionID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("SessionID = %q", key.SessionID)
+	}
+	if key.Subpath != "" {
+		t.Errorf("Subpath = %q, want empty", key.Subpath)
+	}
+}
+
+func TestFilePathToSessionKey_SubagentTranscript(t *testing.T) {
+	projectsDir := filepath.Join("home", "user", ".claude", "projects")
+	abs := filepath.Join(projectsDir, "-home-user-project", "550e8400-e29b-41d4-a716-446655440000", "subagents", "agent-xyz.jsonl")
+
+	key, ok := FilePathToSessionKey(abs, projectsDir)
+	if !ok {
+		t.Fatalf("FilePathToSessionKey returned ok=false for %s", abs)
+	}
+	if key.ProjectKey != "-home-user-project" {
+		t.Errorf("ProjectKey = %q", key.ProjectKey)
+	}
+	if key.SessionID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("SessionID = %q", key.SessionID)
+	}
+	if key.Subpath != "subagents/agent-xyz" {
+		t.Errorf("Subpath = %q, want %q", key.Subpath, "subagents/agent-xyz")
+	}
+}
+
+func TestFilePathToSessionKey_NestedSubagent(t *testing.T) {
+	projectsDir := filepath.Join("home", "user", ".claude", "projects")
+	abs := filepath.Join(projectsDir, "-proj", "sess", "subagents", "workflows", "run-1", "agent-x.jsonl")
+
+	key, ok := FilePathToSessionKey(abs, projectsDir)
+	if !ok {
+		t.Fatalf("nested subagent path was rejected")
+	}
+	if key.Subpath != "subagents/workflows/run-1/agent-x" {
+		t.Errorf("Subpath = %q", key.Subpath)
+	}
+}
+
+func TestFilePathToSessionKey_NotUnderProjectsDir(t *testing.T) {
+	projectsDir := filepath.Join("home", "user", ".claude", "projects")
+	abs := filepath.Join("somewhere", "else", "file.jsonl")
+
+	if _, ok := FilePathToSessionKey(abs, projectsDir); ok {
+		t.Errorf("expected ok=false for path outside projectsDir")
+	}
+}
+
+func TestFilePathToSessionKey_UnrecognizedShape(t *testing.T) {
+	projectsDir := filepath.Join("projects")
+	// Only the project-key component.
+	abs := filepath.Join(projectsDir, "-proj")
+	if _, ok := FilePathToSessionKey(abs, projectsDir); ok {
+		t.Errorf("single-component rel path should be rejected")
+	}
+	// Three components but not a subagent-shaped path: <proj>/<sess>/<bare>
+	abs = filepath.Join(projectsDir, "-proj", "sess", "bare.jsonl")
+	if _, ok := FilePathToSessionKey(abs, projectsDir); ok {
+		t.Errorf("three-component path should be rejected (requires >= 4)")
+	}
+}
+
+func TestFoldSessionSummary_NewSession(t *testing.T) {
+	key := SessionKey{ProjectKey: "p", SessionID: "s"}
+	entries := []SessionStoreEntry{
+		entry(map[string]any{
+			"type":        "user",
+			"timestamp":   "2026-04-23T10:00:00.000Z",
+			"isSidechain": false,
+			"cwd":         "/work",
+			"message":     map[string]any{"content": "hello there"},
+		}),
+	}
+	got := FoldSessionSummary(nil, key, entries)
+
+	if got == nil {
+		t.Fatal("FoldSessionSummary returned nil")
+	}
+	if got.SessionID != "s" {
+		t.Errorf("SessionID = %q", got.SessionID)
+	}
+	if got.Mtime != 0 {
+		t.Errorf("Mtime should be 0 placeholder for new session, got %d", got.Mtime)
+	}
+	if got.Data["cwd"] != "/work" {
+		t.Errorf("cwd = %v", got.Data["cwd"])
+	}
+	if got.Data["first_prompt"] != "hello there" {
+		t.Errorf("first_prompt = %v", got.Data["first_prompt"])
+	}
+	if locked, _ := got.Data["first_prompt_locked"].(bool); !locked {
+		t.Errorf("first_prompt_locked should be true")
+	}
+	if _, ok := got.Data["created_at"]; !ok {
+		t.Errorf("created_at should be set")
+	}
+}
+
+func TestFoldSessionSummary_MergesWithPrev(t *testing.T) {
+	key := SessionKey{ProjectKey: "p", SessionID: "s"}
+
+	first := FoldSessionSummary(nil, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":      "user",
+			"timestamp": "2026-04-23T10:00:00.000Z",
+			"cwd":       "/work",
+			"message":   map[string]any{"content": "first prompt"},
+		}),
+	})
+	// Preserve first.Data for non-leaking check later.
+	firstCwd := first.Data["cwd"]
+	firstPrompt := first.Data["first_prompt"]
+
+	// Second batch: custom title + a tag + another user message (should
+	// NOT override the locked first prompt).
+	second := FoldSessionSummary(first, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":        "custom-title",
+			"customTitle": "My Title",
+		}),
+		entry(map[string]any{
+			"type":    "user",
+			"message": map[string]any{"content": "second prompt"},
+		}),
+		entry(map[string]any{
+			"type": "tag",
+			"tag":  "important",
+		}),
+	})
+
+	if second.Data["custom_title"] != "My Title" {
+		t.Errorf("custom_title not folded: %+v", second.Data)
+	}
+	if second.Data["tag"] != "important" {
+		t.Errorf("tag not folded: %+v", second.Data)
+	}
+	if second.Data["first_prompt"] != firstPrompt {
+		t.Errorf("first_prompt must stay locked: got %v want %v", second.Data["first_prompt"], firstPrompt)
+	}
+	if second.Data["cwd"] != firstCwd {
+		t.Errorf("cwd should be set-once: got %v want %v", second.Data["cwd"], firstCwd)
+	}
+
+	// Tag-entry with empty string should clear the tag.
+	third := FoldSessionSummary(second, key, []SessionStoreEntry{
+		entry(map[string]any{"type": "tag", "tag": ""}),
+	})
+	if _, ok := third.Data["tag"]; ok {
+		t.Errorf("empty tag should clear tag key: %+v", third.Data)
+	}
+}
+
+func TestFoldSessionSummary_IncrementalIndependence(t *testing.T) {
+	// Calling Fold with prev must not mutate the prev summary passed in.
+	key := SessionKey{ProjectKey: "p", SessionID: "s"}
+	prev := FoldSessionSummary(nil, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":      "user",
+			"message":   map[string]any{"content": "first"},
+			"timestamp": "2026-04-23T10:00:00.000Z",
+		}),
+	})
+	snapshot := make(map[string]any, len(prev.Data))
+	for k, v := range prev.Data {
+		snapshot[k] = v
+	}
+
+	_ = FoldSessionSummary(prev, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":        "custom-title",
+			"customTitle": "Added Later",
+		}),
+	})
+
+	// prev.Data should be unchanged.
+	if prev.Data["custom_title"] != nil {
+		t.Errorf("FoldSessionSummary must not mutate prev.Data, saw custom_title=%v", prev.Data["custom_title"])
+	}
+	for k, v := range snapshot {
+		if prev.Data[k] != v {
+			t.Errorf("prev.Data[%q] mutated: was %v now %v", k, v, prev.Data[k])
+		}
+	}
+}
+
+func TestFoldSessionSummary_SkipsSlashCommandForFirstPrompt(t *testing.T) {
+	key := SessionKey{ProjectKey: "p", SessionID: "s"}
+	got := FoldSessionSummary(nil, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":      "user",
+			"message":   map[string]any{"content": "<command-name>loop</command-name>"},
+			"timestamp": "2026-04-23T10:00:00.000Z",
+		}),
+		entry(map[string]any{
+			"type":      "user",
+			"message":   map[string]any{"content": "real first prompt"},
+			"timestamp": "2026-04-23T10:00:01.000Z",
+		}),
+	})
+	if got.Data["first_prompt"] != "real first prompt" {
+		t.Errorf("first_prompt = %v", got.Data["first_prompt"])
+	}
+	if got.Data["command_fallback"] != "loop" {
+		t.Errorf("command_fallback = %v", got.Data["command_fallback"])
+	}
+}
+
+func TestInMemorySessionStore_SummaryStampedWithAppendMtime(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+	tick := int64(5000)
+	s.nowMilli = func() int64 { tick++; return tick }
+
+	key := SessionKey{ProjectKey: "proj", SessionID: "sess"}
+	if err := s.Append(ctx, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":    "user",
+			"message": map[string]any{"content": "hi"},
+		}),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	list, _ := s.ListSessions(ctx, "proj")
+	summaries, _ := s.ListSessionSummaries(ctx, "proj")
+	if len(list) != 1 || len(summaries) != 1 {
+		t.Fatalf("want 1 list + 1 summary, got list=%d summary=%d", len(list), len(summaries))
+	}
+	if summaries[0].Mtime != list[0].Mtime {
+		t.Errorf("summary mtime %d must match list mtime %d (shared clock invariant)",
+			summaries[0].Mtime, list[0].Mtime)
+	}
+	if summaries[0].Mtime == 0 {
+		t.Errorf("adapter must overwrite fold's 0 placeholder with a real mtime")
+	}
+}
+
+func TestInMemorySessionStore_SubagentAppendDoesNotFoldSummary(t *testing.T) {
+	ctx := context.Background()
+	s := NewInMemorySessionStore()
+	// Append ONLY to a subagent key.
+	key := SessionKey{ProjectKey: "proj", SessionID: "sess", Subpath: "subagents/agent-x"}
+	if err := s.Append(ctx, key, []SessionStoreEntry{
+		entry(map[string]any{
+			"type":        "custom-title",
+			"customTitle": "SHOULD NOT APPEAR",
+		}),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	summaries, _ := s.ListSessionSummaries(ctx, "proj")
+	for _, sum := range summaries {
+		if sum.Data["custom_title"] == "SHOULD NOT APPEAR" {
+			t.Errorf("subagent append must not contribute to main summary: %+v", sum)
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -85,7 +85,7 @@ func (ToolUseBlock) contentBlockMarker() {}
 // ToolResultBlock represents a tool result content block.
 type ToolResultBlock struct {
 	ToolUseID string `json:"tool_use_id"`
-	Content   any    `json:"content,omitempty"`   // string | []map[string]any | nil
+	Content   any    `json:"content,omitempty"` // string | []map[string]any | nil
 	IsError   *bool  `json:"is_error,omitempty"`
 }
 
@@ -130,10 +130,10 @@ func (ServerToolResultBlock) contentBlockMarker() {}
 
 // UserMessage represents a user message.
 type UserMessage struct {
-	Content          any            `json:"content"`                      // string | []ContentBlock
-	UUID             string         `json:"uuid,omitempty"`
-	ParentToolUseID  string         `json:"parent_tool_use_id,omitempty"`
-	ToolUseResult    map[string]any `json:"tool_use_result,omitempty"`
+	Content         any            `json:"content"` // string | []ContentBlock
+	UUID            string         `json:"uuid,omitempty"`
+	ParentToolUseID string         `json:"parent_tool_use_id,omitempty"`
+	ToolUseResult   map[string]any `json:"tool_use_result,omitempty"`
 }
 
 func (UserMessage) messageMarker() {}
@@ -239,14 +239,14 @@ type TaskNotificationMessage struct {
 
 // ResultMessage contains cost and usage information for a completed query.
 type ResultMessage struct {
-	Subtype          string         `json:"subtype"`
-	DurationMs       int            `json:"duration_ms"`
-	DurationAPIMs    int            `json:"duration_api_ms"`
-	IsError          bool           `json:"is_error"`
-	Errors           []any          `json:"errors,omitempty"`
-	NumTurns         int            `json:"num_turns"`
-	SessionID        string         `json:"session_id"`
-	StopReason       string         `json:"stop_reason,omitempty"`
+	Subtype       string `json:"subtype"`
+	DurationMs    int    `json:"duration_ms"`
+	DurationAPIMs int    `json:"duration_api_ms"`
+	IsError       bool   `json:"is_error"`
+	Errors        []any  `json:"errors,omitempty"`
+	NumTurns      int    `json:"num_turns"`
+	SessionID     string `json:"session_id"`
+	StopReason    string `json:"stop_reason,omitempty"`
 	// TerminalReason describes why the session terminated (e.g. "completed",
 	// "aborted_tools", "max_turns", "blocking_limit"). Empty when not
 	// provided by the CLI.
@@ -311,14 +311,14 @@ type ContextUsage struct {
 
 // SDKSessionInfo contains session metadata returned by ListSessions and GetSessionInfo.
 type SDKSessionInfo struct {
-	SessionID    string `json:"session_id"`
-	Summary      string `json:"summary"`
-	LastModified int64  `json:"last_modified"`
-	FileSize     *int64 `json:"file_size,omitempty"`
-	CustomTitle  string `json:"custom_title,omitempty"`
-	FirstPrompt  string `json:"first_prompt,omitempty"`
-	GitBranch    string `json:"git_branch,omitempty"`
-	Cwd          string `json:"cwd,omitempty"`
+	SessionID    string  `json:"session_id"`
+	Summary      string  `json:"summary"`
+	LastModified int64   `json:"last_modified"`
+	FileSize     *int64  `json:"file_size,omitempty"`
+	CustomTitle  string  `json:"custom_title,omitempty"`
+	FirstPrompt  string  `json:"first_prompt,omitempty"`
+	GitBranch    string  `json:"git_branch,omitempty"`
+	Cwd          string  `json:"cwd,omitempty"`
 	Tag          *string `json:"tag,omitempty"`
 	CreatedAt    *int64  `json:"created_at,omitempty"`
 }
@@ -339,4 +339,52 @@ type SessionMessage struct {
 	SessionID       string `json:"session_id"`
 	Message         any    `json:"message"`
 	ParentToolUseID string `json:"parent_tool_use_id,omitempty"`
+}
+
+// SessionKey identifies a single transcript stream in a [SessionStore].
+//
+// ProjectKey is the per-project namespace (typically derived via
+// [ProjectKeyForDirectory] from an absolute project directory). SessionID is
+// the session's UUID. Subpath is empty for the main session transcript and
+// non-empty for sibling streams such as subagent transcripts (e.g.
+// "subagents/agent-xyz").
+type SessionKey struct {
+	ProjectKey string `json:"project_key"`
+	SessionID  string `json:"session_id"`
+	Subpath    string `json:"subpath,omitempty"`
+}
+
+// SessionStoreEntry is one JSONL line from a transcript, represented as a
+// parsed JSON object. [SessionStore] adapters persist these verbatim —
+// they must round-trip through [SessionStore.Append] and [SessionStore.Load]
+// without the adapter interpreting individual fields.
+type SessionStoreEntry = map[string]any
+
+// SessionStoreListEntry is one row returned by
+// [SessionStoreLister.ListSessions]. Mtime is the adapter's storage write
+// time in Unix epoch milliseconds, and must share a clock with the mtime
+// embedded in [SessionSummaryEntry] for the same session so the fast-path
+// staleness check (summary.Mtime < list mtime) is meaningful.
+type SessionStoreListEntry struct {
+	SessionID string `json:"session_id"`
+	Mtime     int64  `json:"mtime"`
+}
+
+// SessionSummaryEntry is a per-session summary sidecar maintained by
+// adapters that implement [SessionStoreSummarizer]. Mtime is the storage
+// write time in Unix epoch milliseconds. Data is opaque state produced by
+// [FoldSessionSummary] — adapters persist it verbatim and do not interpret
+// individual keys.
+type SessionSummaryEntry struct {
+	SessionID string         `json:"session_id"`
+	Mtime     int64          `json:"mtime"`
+	Data      map[string]any `json:"data"`
+}
+
+// SessionListSubkeysKey identifies the main transcript whose sibling
+// subkeys (subagent transcripts and other sub-streams) should be listed
+// via [SessionStoreSubkeys.ListSubkeys].
+type SessionListSubkeysKey struct {
+	ProjectKey string `json:"project_key"`
+	SessionID  string `json:"session_id"`
 }


### PR DESCRIPTION
Closes #152. Part of umbrella #110.

## Summary
- Adds `SessionStore` required interface + 4 optional extension interfaces (`SessionStoreLister`, `SessionStoreSummarizer`, `SessionStoreDeleter`, `SessionStoreSubkeys`)
- Adds `InMemorySessionStore` reference implementation that satisfies all 5
- Adds pure helpers: `ProjectKeyForDirectory`, `FilePathToSessionKey`, `FoldSessionSummary`
- Adds foundational types in `types.go` (`SessionKey`, `SessionStoreEntry`, `SessionStoreListEntry`, `SessionSummaryEntry`, `SessionListSubkeysKey`)
- Port of Python SDK v0.1.64 (PR #837) — matches semantics exactly while idiomatic for Go (context-first, `(value, error)` returns, `sync.RWMutex` for thread safety, defensive slice/map copies)
- No runtime effect — just types and a working in-memory store

## Out of scope (later sub-issues)
- Mirror wiring (#153 Sub B)
- Resume from store (#154 Sub C)
- Store-backed read/write helpers (#155 Sub D, #156 Sub E)

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` clean
- [x] 26 new test cases exercising Append/Load/List/Delete/Subkeys/fold helpers, including concurrent-append race, interface conformance, context cancellation, cascade-vs-targeted Delete, and summary sidecar stamping