### PR TITLE
release: v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-04-27
+
+This release lands feature-parity with the Python and TypeScript SDKs across
+21 features audited against `anthropics/claude-agent-sdk-python` and
+`anthropics/claude-agent-sdk-typescript`, plus the **full SessionStore**
+adapter system (port of Python SDK v0.1.64 PR #837), one critical content-
+parser bugfix, and runnable examples. Total ~12,000 LOC across 27 merged
+PRs.
+
+> **SessionStore stability**: the SessionStore interface family
+> (`SessionStore`, `SessionStoreLister`, `SessionStoreSummarizer`,
+> `SessionStoreDeleter`, `SessionStoreSubkeys`), the `*FromStore` /
+> `*ViaStore` helpers, and `Options.SessionStore` ship under SemVer
+> compatibility but may evolve in subsequent minor releases based on
+> adapter-author feedback. Treat the API as load-bearing for embedders
+> and pin a minor version if you depend on its exact shape.
+
 ### Added
 
 - `examples/session_store/` demonstrating end-to-end SessionStore usage with `InMemorySessionStore`: mirror mode wiring, store-backed read/mutation helpers, `MirrorErrorMessage` handling, and `Client.CloseContext` deadline behavior. Plus `examples/session_store_filesystem/` showing how to write a custom adapter (pure-Go filesystem-backed implementation of `SessionStore` + `SessionStoreLister` + `SessionStoreDeleter` + `SessionStoreSubkeys`). ([#164](https://github.com/Flohs/claude-agent-sdk-go/issues/164))
@@ -47,7 +64,6 @@
 - Documentation: the `SessionStore.Append` GoDoc now states the context-honoring contract explicitly so adapters know that ignoring `ctx` causes a per-call goroutine leak in the SDK's mirror batcher. The `isSafeSubpath` GoDoc no longer claims a symlink-escape check that the lexical implementation does not perform. ([#162](https://github.com/Flohs/claude-agent-sdk-go/issues/162))
 - Assistant messages containing server-side tool blocks (`web_search`, `web_fetch`, `advisor`, etc.) previously had those blocks silently dropped by the content parser, which could produce `AssistantMessage{Content: []}` for messages that only carried server-tool blocks. The parser now emits typed `ServerToolUseBlock` / `ServerToolResultBlock` blocks. ([#109](https://github.com/Flohs/claude-agent-sdk-go/issues/109))
 - Test helper `buildTestEnv` was out of sync with `Connect()`'s env-building logic after the trace-propagation change. The helper now mirrors the `TRACEPARENT` / `TRACESTATE` forwarding and a new `TestConnectEnv_TraceContext` covers all three cases (unset, TraceParent only, both headers). Also adds `TestParseMessage_TaskProgress_Summary` for the `Summary` field introduced with `AgentProgressSummaries`. ([#150](https://github.com/Flohs/claude-agent-sdk-go/issues/150))
-
 - `ThinkingConfigAdaptive` and `ThinkingConfigDisabled` now correctly map to `--thinking adaptive` / `--thinking disabled` CLI flags instead of incorrectly using `--max-thinking-tokens`. `ThinkingConfigEnabled` and the deprecated `MaxThinkingTokens` field continue to use `--max-thinking-tokens`. ([#99](https://github.com/Flohs/claude-agent-sdk-go/issues/99))
 
 ## [1.5.0] - 2026-04-08

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -20,7 +20,7 @@ import (
 const (
 	defaultMaxBufferSize       = 1024 * 1024 // 1MB
 	minimumClaudeCodeVersion   = "2.1.90"
-	sdkVersion                 = "1.5.0"
+	sdkVersion                 = "1.6.0"
 )
 
 // SubprocessTransport implements Transport using the Claude Code CLI subprocess.


### PR DESCRIPTION
## Release v1.6.0

Bumps \`sdkVersion\` from 1.5.0 → 1.6.0 and finalizes the changelog. After
merge: tag and push, then create the GitHub release.

## Scope of this release

This is a **MINOR** version bump — additive only against released v1.5.0.
The pre-release breaking change to \`*ViaStore\` mutator signatures
(variadic → \`StoreMutationOptions\`) was made within the same unreleased
window and never reached a tagged version, so it is not breaking from
the released-API perspective.

## Highlights since v1.5.0

- **21 feature-parity ports** from Python/TypeScript SDKs (#111–#129)
- **Full SessionStore adapter system** (#152–#156, #163, #165) — port of Python SDK v0.1.64 PR #837. ~5900 LOC. Includes \`InMemorySessionStore\`, mirror write path, resume materialization, store-backed read/mutation helpers, and runnable examples.
- **Critical bugfix**: server-side tool content blocks (\`web_search\`, \`web_fetch\`, etc.) were previously silently dropped by the parser (#109).
- **Test gap closure** + new \`examples/skills\`, \`examples/hooks\` lifecycle, \`examples/session_store\`, \`examples/session_store_filesystem\` (#150, #164).
- **6 review-finding fixes** to SessionStore including silent-mirror-data-loss when \`Options.Env[\"CLAUDE_CONFIG_DIR\"]\` was set (#162).

## SessionStore stability hedge

The CHANGELOG calls out that the SessionStore API ships under SemVer
compatibility but may evolve in subsequent minor releases based on
adapter-author feedback. Treat as load-bearing for embedders; pin a
minor version if you depend on its exact shape.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 ./...\` clean
- [x] CHANGELOG \`[Unreleased]\` is now empty; all entries moved to \`[1.6.0] - 2026-04-27\`
- [x] \`sdkVersion\` constant updated

## Post-merge steps (run on \`main\`)

```
git checkout main && git pull origin main
git tag v1.6.0
git push origin v1.6.0
gh release create v1.6.0 --title \"v1.6.0\" --notes \"See [CHANGELOG.md](https://github.com/Flohs/claude-agent-sdk-go/blob/main/CHANGELOG.md) for details.\"
```