### PR TITLE
chore: add 2-day Dependabot cooldown (#168)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 2
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `.github/dependabot.yml` — added `cooldown.default-days: 2` to both `gomod` and `github-actions` ecosystems so Dependabot waits at least 2 days after a release before proposing the update. ([#168](https://github.com/Flohs/claude-agent-sdk-go/issues/168))
+
 ## [1.6.0] - 2026-04-27
 
 This release lands feature-parity with the Python and TypeScript SDKs across


### PR DESCRIPTION
Closes #168

## Summary
- Added `cooldown.default-days: 2` to both `gomod` and `github-actions` entries in `.github/dependabot.yml`. Dependabot will now wait at least 2 days after a release is published before opening an update PR, avoiding immediately-yanked or hot-fixed versions.
- Updated `CHANGELOG.md` under `[Unreleased] / Changed`.

## Test plan
- [ ] CI green (build, vet, test, lint, govulncheck)
- [ ] `.github/dependabot.yml` still parses (GitHub will surface a Dependabot config error in the repo's Insights → Dependency graph → Dependabot tab if not)