### PR TITLE
feat: add AssistantMessageErrorModelNotFound constant (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `EffortXHigh` (`"xhigh"`) constant for the `Effort` type, enabling Opus 4.7's extended thinking effort level. Port of Python SDK v0.1.74 / TypeScript SDK v0.3.144. ([#170](https://github.com/Flohs/claude-agent-sdk-go/issues/170))
+- `AssistantMessageErrorModelNotFound` constant for the `AssistantMessageError` type, surfacing `"model_not_found"` errors from the API. Port of TypeScript SDK v0.3.144. ([#171](https://github.com/Flohs/claude-agent-sdk-go/issues/171))
 
 ### Changed
 

--- a/types.go
+++ b/types.go
@@ -148,6 +148,7 @@ const (
 	AssistantMessageErrorInvalidRequest AssistantMessageError = "invalid_request"
 	AssistantMessageErrorServer         AssistantMessageError = "server_error"
 	AssistantMessageErrorUnknown        AssistantMessageError = "unknown"
+	AssistantMessageErrorModelNotFound  AssistantMessageError = "model_not_found"
 )
 
 // AssistantMessage represents an assistant message with content blocks.


### PR DESCRIPTION
## Summary

- Adds `AssistantMessageErrorModelNotFound` (`"model_not_found"`) constant to the `AssistantMessageError` type
- Port of TypeScript SDK v0.3.144

## Changes

- `types.go`: added `AssistantMessageErrorModelNotFound AssistantMessageError = "model_not_found"`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `AssistantMessageErrorModelNotFound` compiles and is accessible
- [ ] Verify it matches the string `"model_not_found"` as returned by the CLI

Closes #171

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_