### PR TITLE
feat: add ResultMessage.APIErrorStatus field (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `EffortXHigh` (`"xhigh"`) constant for the `Effort` type, enabling Opus 4.7's extended thinking effort level. Port of Python SDK v0.1.74 / TypeScript SDK v0.3.144. ([#170](https://github.com/Flohs/claude-agent-sdk-go/issues/170))
 - `AssistantMessageErrorModelNotFound` constant for the `AssistantMessageError` type, surfacing `"model_not_found"` errors from the API. Port of TypeScript SDK v0.3.144. ([#171](https://github.com/Flohs/claude-agent-sdk-go/issues/171))
+- `APIErrorStatus *int` field on `ResultMessage` that surfaces the underlying HTTP status code when `is_error` is true (e.g. `429`, `529`). Port of TypeScript SDK v0.3.144. ([#172](https://github.com/Flohs/claude-agent-sdk-go/issues/172))
 
 ### Changed
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -215,6 +215,12 @@ func parseResultMessage(data map[string]any) (*ResultMessage, error) {
 		msg.Errors = errors
 	}
 
+	if v, ok := data["api_error_status"]; ok {
+		if status := intFromAny(v); status != 0 {
+			msg.APIErrorStatus = &status
+		}
+	}
+
 	if cost, ok := data["total_cost_usd"].(float64); ok {
 		msg.TotalCostUSD = &cost
 	}

--- a/types.go
+++ b/types.go
@@ -269,7 +269,11 @@ type ResultMessage struct {
 	// TerminalReason describes why the session terminated (e.g. "completed",
 	// "aborted_tools", "max_turns", "blocking_limit"). Empty when not
 	// provided by the CLI.
-	TerminalReason   string         `json:"terminal_reason,omitempty"`
+	TerminalReason string `json:"terminal_reason,omitempty"`
+	// APIErrorStatus is the HTTP status code (e.g. 429, 500, 529) from a
+	// failing API call when IsError is true. Zero when not provided by the
+	// CLI (requires CLI >= v2.1.110).
+	APIErrorStatus   *int           `json:"api_error_status,omitempty"`
 	TotalCostUSD     *float64       `json:"total_cost_usd,omitempty"`
 	Usage            map[string]any `json:"usage,omitempty"`
 	Result           string         `json:"result,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `APIErrorStatus *int` field to `ResultMessage` that surfaces the underlying HTTP status code when `is_error` is true (e.g. `429`, `529`)
- Port of TypeScript SDK v0.3.144

## Changes

- `types.go`: added `APIErrorStatus *int` field on `ResultMessage`
- `message_parser.go`: parse `api_error_status` field in `parseResultMessage()`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `ResultMessage.APIErrorStatus` is populated when `is_error` is true and the field is present in the JSON
- [ ] Verify it is `nil` when `is_error` is false or field is absent

Closes #172

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_