### PR TITLE
fix: recover panics in StderrCallback to isolate caller errors (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 - `.github/dependabot.yml` — added `cooldown.default-days: 2` to both `gomod` and `github-actions` ecosystems so Dependabot waits at least 2 days after a release before proposing the update. ([#168](https://github.com/Flohs/claude-agent-sdk-go/issues/168))
 
+### Fixed
+
+- Panics inside user-supplied `Options.StderrCallback` functions are now recovered and logged, preventing a crashing callback from terminating the subprocess reader goroutine. Port of TypeScript SDK v0.3.144. ([#173](https://github.com/Flohs/claude-agent-sdk-go/issues/173))
+
+
 ## [1.6.0] - 2026-04-27
 
 This release lands feature-parity with the Python and TypeScript SDKs across

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -378,12 +378,18 @@ func (t *SubprocessTransport) handleStderr() {
 			continue
 		}
 		if t.options.Stderr != nil {
-			func() {
-				defer func() { recover() }()
-				t.options.Stderr(line)
-			}()
+			t.callStderr(line)
 		}
 	}
+}
+
+func (t *SubprocessTransport) callStderr(line string) {
+	defer func() {
+		if r := recover(); r != nil {
+			_ = r
+		}
+	}()
+	t.options.Stderr(line)
 }
 
 func (t *SubprocessTransport) buildCommand() []string {

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -386,7 +386,7 @@ func (t *SubprocessTransport) handleStderr() {
 func (t *SubprocessTransport) callStderr(line string) {
 	defer func() {
 		if r := recover(); r != nil {
-			_ = r
+			fmt.Fprintf(os.Stderr, "Warning: StderrCallback panicked: %v\n", r)
 		}
 	}()
 	t.options.Stderr(line)

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -378,7 +378,10 @@ func (t *SubprocessTransport) handleStderr() {
 			continue
 		}
 		if t.options.Stderr != nil {
-			t.options.Stderr(line)
+			func() {
+				defer func() { recover() }()
+				t.options.Stderr(line)
+			}()
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Panics inside user-supplied `Options.StderrCallback` functions are now recovered and logged, preventing a crashing callback from terminating the subprocess reader goroutine
- Port of TypeScript SDK v0.3.144

## Changes

- `subprocess_transport.go`: wrapped `StderrCallback` invocation in `recover()` in `handleStderr()`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify that a panicking `StderrCallback` does not crash the goroutine
- [ ] Verify the stderr reader continues operating after a callback panic

Closes #173

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_