### PR TITLE
fix: change PermissionSuggestions type to []map[string]any (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - `.github/dependabot.yml` — added `cooldown.default-days: 2` to both `gomod` and `github-actions` ecosystems so Dependabot waits at least 2 days after a release before proposing the update. ([#168](https://github.com/Flohs/claude-agent-sdk-go/issues/168))
+- `PermissionRequestHookInput.PermissionSuggestions` changed from `[]any` to `[]map[string]any` for correct type fidelity with the CLI protocol. ([#175](https://github.com/Flohs/claude-agent-sdk-go/issues/175))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - `.github/dependabot.yml` — added `cooldown.default-days: 2` to both `gomod` and `github-actions` ecosystems so Dependabot waits at least 2 days after a release before proposing the update. ([#168](https://github.com/Flohs/claude-agent-sdk-go/issues/168))
-- `PermissionRequestHookInput.PermissionSuggestions` changed from `[]any` to `[]map[string]any` for correct type fidelity with the CLI protocol. ([#175](https://github.com/Flohs/claude-agent-sdk-go/issues/175))
+- **Breaking:** `PermissionRequestHookInput.PermissionSuggestions` changed from `[]any` to `[]map[string]any` for correct type fidelity with the CLI protocol. Callers that previously type-asserted each element to `map[string]any` can drop the assertion; callers that handled non-map entries will need to adapt. ([#175](https://github.com/Flohs/claude-agent-sdk-go/issues/175))
 
 ### Fixed
 

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -48,7 +48,7 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			SubagentContext: parseSubagentContext(input),
 			ToolName:        stringField(input, "tool_name"),
 			ToolInput:       mapField(input, "tool_input"),
-			PermissionSuggestions: sliceField(input, "permission_suggestions"),
+			PermissionSuggestions: mapSliceField(input, "permission_suggestions"),
 		}, nil
 
 	case HookEventUserPromptSubmit:
@@ -145,4 +145,18 @@ func mapField(m map[string]any, key string) map[string]any {
 func sliceField(m map[string]any, key string) []any {
 	v, _ := m[key].([]any)
 	return v
+}
+
+func mapSliceField(m map[string]any, key string) []map[string]any {
+	raw, _ := m[key].([]any)
+	if raw == nil {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		if entry, ok := item.(map[string]any); ok {
+			result = append(result, entry)
+		}
+	}
+	return result
 }

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -142,11 +142,6 @@ func mapField(m map[string]any, key string) map[string]any {
 	return v
 }
 
-func sliceField(m map[string]any, key string) []any {
-	v, _ := m[key].([]any)
-	return v
-}
-
 func mapSliceField(m map[string]any, key string) []map[string]any {
 	raw, _ := m[key].([]any)
 	if raw == nil {

--- a/hooks.go
+++ b/hooks.go
@@ -99,7 +99,7 @@ type PermissionRequestHookInput struct {
 	SubagentContext
 	ToolName              string         `json:"tool_name"`
 	ToolInput             map[string]any `json:"tool_input"`
-	PermissionSuggestions []any          `json:"permission_suggestions,omitempty"`
+	PermissionSuggestions []map[string]any `json:"permission_suggestions,omitempty"`
 }
 
 func (*PermissionRequestHookInput) hookInputMarker() {}


### PR DESCRIPTION
## Summary

- `PermissionRequestHookInput.PermissionSuggestions` changed from `[]any` to `[]map[string]any` for correct type fidelity with the CLI protocol
- Each suggestion is a structured object, not an arbitrary value

## Changes

- `hooks.go`: changed `PermissionSuggestions []any` to `PermissionSuggestions []map[string]any`
- `hook_input_parser.go`: added `mapSliceField()` helper and updated permission_suggestions parsing
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify code that reads `PermissionSuggestions` can access fields without type assertion to `map[string]any`
- [ ] Verify backwards compatibility: existing code using `[]any` type assertions still compiles with minor update

Closes #175

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_