### PR TITLE
feat: add SandboxNetworkConfig domain allowlist/denylist fields (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `EffortXHigh` (`"xhigh"`) constant for the `Effort` type, enabling Opus 4.7's extended thinking effort level. Port of Python SDK v0.1.74 / TypeScript SDK v0.3.144. ([#170](https://github.com/Flohs/claude-agent-sdk-go/issues/170))
 - `AssistantMessageErrorModelNotFound` constant for the `AssistantMessageError` type, surfacing `"model_not_found"` errors from the API. Port of TypeScript SDK v0.3.144. ([#171](https://github.com/Flohs/claude-agent-sdk-go/issues/171))
 - `APIErrorStatus *int` field on `ResultMessage` that surfaces the underlying HTTP status code when `is_error` is true (e.g. `429`, `529`). Port of TypeScript SDK v0.3.144. ([#172](https://github.com/Flohs/claude-agent-sdk-go/issues/172))
+- `AllowedDomains`, `DeniedDomains`, `AllowManagedDomainsOnly`, and `AllowMachLookup` fields on `SandboxNetworkConfig` for fine-grained network domain control in sandboxed environments. Port of TypeScript SDK v0.3.144. ([#182](https://github.com/Flohs/claude-agent-sdk-go/issues/182))
 
 ### Changed
 

--- a/options.go
+++ b/options.go
@@ -130,6 +130,14 @@ type SandboxNetworkConfig struct {
 	AllowLocalBinding   *bool    `json:"allowLocalBinding,omitempty"`
 	HTTPProxyPort       *int     `json:"httpProxyPort,omitempty"`
 	SOCKSProxyPort      *int     `json:"socksProxyPort,omitempty"`
+	// AllowedDomains restricts outbound connections to the listed hostnames.
+	AllowedDomains []string `json:"allowedDomains,omitempty"`
+	// DeniedDomains blocks outbound connections to the listed hostnames.
+	DeniedDomains []string `json:"deniedDomains,omitempty"`
+	// AllowManagedDomainsOnly restricts traffic to organization-managed domains.
+	AllowManagedDomainsOnly *bool `json:"allowManagedDomainsOnly,omitempty"`
+	// AllowMachLookup permits mach port lookup (macOS only).
+	AllowMachLookup *bool `json:"allowMachLookup,omitempty"`
 }
 
 // SandboxIgnoreViolations specifies violations to ignore in sandbox.


### PR DESCRIPTION
## Summary

- Adds `AllowedDomains`, `DeniedDomains`, `AllowManagedDomainsOnly`, and `AllowMachLookup` fields to `SandboxNetworkConfig` for fine-grained network domain control in sandboxed environments
- Port of TypeScript SDK v0.3.144

## Changes

- `options.go`: added four new fields to `SandboxNetworkConfig`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `AllowedDomains []string` and `DeniedDomains []string` marshal correctly to the CLI
- [ ] Verify `AllowManagedDomainsOnly bool` and `AllowMachLookup bool` forward correctly

Closes #182

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_