### PR TITLE
feat: add Options.StrictMcpConfig flag (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `AssistantMessageErrorModelNotFound` constant for the `AssistantMessageError` type, surfacing `"model_not_found"` errors from the API. Port of TypeScript SDK v0.3.144. ([#171](https://github.com/Flohs/claude-agent-sdk-go/issues/171))
 - `APIErrorStatus *int` field on `ResultMessage` that surfaces the underlying HTTP status code when `is_error` is true (e.g. `429`, `529`). Port of TypeScript SDK v0.3.144. ([#172](https://github.com/Flohs/claude-agent-sdk-go/issues/172))
 - `AllowedDomains`, `DeniedDomains`, `AllowManagedDomainsOnly`, and `AllowMachLookup` fields on `SandboxNetworkConfig` for fine-grained network domain control in sandboxed environments. Port of TypeScript SDK v0.3.144. ([#182](https://github.com/Flohs/claude-agent-sdk-go/issues/182))
+- `Options.StrictMcpConfig bool` field forwarded as `--strict-mcp-config` to the CLI, telling it to use only MCP servers passed via `McpServers` and ignore project, user, and global MCP configurations. Enables fully deterministic server sets for reproducible deployments. Port of TypeScript SDK v0.3.128. ([#178](https://github.com/Flohs/claude-agent-sdk-go/issues/178))
 
 ### Changed
 

--- a/options.go
+++ b/options.go
@@ -242,6 +242,10 @@ type Options struct {
 	// on task_progress messages. When set, task progress messages carry a
 	// Summary field describing the subagent's current activity.
 	AgentProgressSummaries bool
+	// StrictMcpConfig, when true, tells the CLI to only use MCP servers passed
+	// via McpServers, ignoring project, user, and global MCP configurations.
+	// Enables fully deterministic server sets for reproducible deployments.
+	StrictMcpConfig bool
 	// ForkSession forks resumed sessions to a new session ID.
 	ForkSession bool
 	// Agents defines custom agent configurations.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -534,6 +534,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--agent-progress-summaries")
 	}
 
+	if opts.StrictMcpConfig {
+		cmd = append(cmd, "--strict-mcp-config")
+	}
+
 	if opts.ForkSession {
 		cmd = append(cmd, "--fork-session")
 	}


### PR DESCRIPTION
## Summary

- Adds `Options.StrictMcpConfig bool` field forwarded as `--strict-mcp-config` to the CLI subprocess
- When enabled, the CLI rejects sessions where any MCP server is not explicitly listed in the session config
- Port of TypeScript SDK v0.3.128

## Changes

- `options.go`: added `StrictMcpConfig bool` field to `Options`
- `subprocess_transport.go`: forwards `--strict-mcp-config` flag when set in `buildCommand()`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `--strict-mcp-config` flag appears in subprocess args when `Options.StrictMcpConfig = true`
- [ ] Verify flag is absent when `Options.StrictMcpConfig = false`

Closes #178

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_