### PR TITLE
feat: add Options.ForwardSubagentText flag (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `APIErrorStatus *int` field on `ResultMessage` that surfaces the underlying HTTP status code when `is_error` is true (e.g. `429`, `529`). Port of TypeScript SDK v0.3.144. ([#172](https://github.com/Flohs/claude-agent-sdk-go/issues/172))
 - `AllowedDomains`, `DeniedDomains`, `AllowManagedDomainsOnly`, and `AllowMachLookup` fields on `SandboxNetworkConfig` for fine-grained network domain control in sandboxed environments. Port of TypeScript SDK v0.3.144. ([#182](https://github.com/Flohs/claude-agent-sdk-go/issues/182))
 - `Options.StrictMcpConfig bool` field forwarded as `--strict-mcp-config` to the CLI, telling it to use only MCP servers passed via `McpServers` and ignore project, user, and global MCP configurations. Enables fully deterministic server sets for reproducible deployments. Port of TypeScript SDK v0.3.128. ([#178](https://github.com/Flohs/claude-agent-sdk-go/issues/178))
+- `Options.ForwardSubagentText bool` field forwarded as `--forward-subagent-text` to the CLI, enabling forwarding of subagent text messages to the parent session stream. Port of TypeScript SDK v0.3.130. ([#179](https://github.com/Flohs/claude-agent-sdk-go/issues/179))
 
 ### Changed
 

--- a/options.go
+++ b/options.go
@@ -246,6 +246,8 @@ type Options struct {
 	// via McpServers, ignoring project, user, and global MCP configurations.
 	// Enables fully deterministic server sets for reproducible deployments.
 	StrictMcpConfig bool
+	// ForwardSubagentText, when true, streams subagent text deltas to SDK consumers.
+	ForwardSubagentText bool
 	// ForkSession forks resumed sessions to a new session ID.
 	ForkSession bool
 	// Agents defines custom agent configurations.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -538,6 +538,10 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = append(cmd, "--strict-mcp-config")
 	}
 
+	if opts.ForwardSubagentText {
+		cmd = append(cmd, "--forward-subagent-text")
+	}
+
 	if opts.ForkSession {
 		cmd = append(cmd, "--fork-session")
 	}


### PR DESCRIPTION
## Summary

- Adds `Options.ForwardSubagentText bool` field forwarded as `--forward-subagent-text` to the CLI subprocess
- When enabled, subagent text messages are forwarded to the parent session stream
- Port of TypeScript SDK v0.3.130

## Changes

- `options.go`: added `ForwardSubagentText bool` field to `Options`
- `subprocess_transport.go`: forwards `--forward-subagent-text` flag when set in `buildCommand()`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `--forward-subagent-text` flag appears in subprocess args when `Options.ForwardSubagentText = true`
- [ ] Verify flag is absent when `Options.ForwardSubagentText = false`

Closes #179

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_