### PR TITLE
feat: add ResultMessage.Origin field (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `AllowedDomains`, `DeniedDomains`, `AllowManagedDomainsOnly`, and `AllowMachLookup` fields on `SandboxNetworkConfig` for fine-grained network domain control in sandboxed environments. Port of TypeScript SDK v0.3.144. ([#182](https://github.com/Flohs/claude-agent-sdk-go/issues/182))
 - `Options.StrictMcpConfig bool` field forwarded as `--strict-mcp-config` to the CLI, telling it to use only MCP servers passed via `McpServers` and ignore project, user, and global MCP configurations. Enables fully deterministic server sets for reproducible deployments. Port of TypeScript SDK v0.3.128. ([#178](https://github.com/Flohs/claude-agent-sdk-go/issues/178))
 - `Options.ForwardSubagentText bool` field forwarded as `--forward-subagent-text` to the CLI, enabling forwarding of subagent text messages to the parent session stream. Port of TypeScript SDK v0.3.130. ([#179](https://github.com/Flohs/claude-agent-sdk-go/issues/179))
+- `Origin string` field on `ResultMessage` that surfaces the triggering message's `SDKMessageOrigin`, allowing consumers to distinguish user-prompted results from task-notification followups. Port of TypeScript SDK v0.2.126. ([#180](https://github.com/Flohs/claude-agent-sdk-go/issues/180))
 
 ### Changed
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -208,6 +208,7 @@ func parseResultMessage(data map[string]any) (*ResultMessage, error) {
 		SessionID:      stringField(data, "session_id"),
 		StopReason:     stringField(data, "stop_reason"),
 		TerminalReason: stringField(data, "terminal_reason"),
+		Origin:         stringField(data, "origin"),
 		Result:         stringField(data, "result"),
 	}
 

--- a/types.go
+++ b/types.go
@@ -273,7 +273,10 @@ type ResultMessage struct {
 	// APIErrorStatus is the HTTP status code (e.g. 429, 500, 529) from a
 	// failing API call when IsError is true. Zero when not provided by the
 	// CLI (requires CLI >= v2.1.110).
-	APIErrorStatus   *int           `json:"api_error_status,omitempty"`
+	APIErrorStatus *int `json:"api_error_status,omitempty"`
+	// Origin forwards the triggering message's origin so consumers can
+	// distinguish user-prompted results from task-notification followups.
+	Origin           string         `json:"origin,omitempty"`
 	TotalCostUSD     *float64       `json:"total_cost_usd,omitempty"`
 	Usage            map[string]any `json:"usage,omitempty"`
 	Result           string         `json:"result,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `Origin string` field to `ResultMessage` that surfaces the triggering message's `SDKMessageOrigin`
- Allows consumers to distinguish user-prompted results from task-notification followups
- Port of TypeScript SDK v0.2.126

## Changes

- `types.go`: added `Origin string` field to `ResultMessage`
- `message_parser.go`: parse `origin` field in `parseResultMessage()`
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `ResultMessage.Origin` is populated when the `origin` field is present in the JSON
- [ ] Verify it is empty string when `origin` is absent

Closes #180

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_