### PR TITLE
feat: add RequestID, SubagentType, TaskDescription fields to message types (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `Options.StrictMcpConfig bool` field forwarded as `--strict-mcp-config` to the CLI, telling it to use only MCP servers passed via `McpServers` and ignore project, user, and global MCP configurations. Enables fully deterministic server sets for reproducible deployments. Port of TypeScript SDK v0.3.128. ([#178](https://github.com/Flohs/claude-agent-sdk-go/issues/178))
 - `Options.ForwardSubagentText bool` field forwarded as `--forward-subagent-text` to the CLI, enabling forwarding of subagent text messages to the parent session stream. Port of TypeScript SDK v0.3.130. ([#179](https://github.com/Flohs/claude-agent-sdk-go/issues/179))
 - `Origin string` field on `ResultMessage` that surfaces the triggering message's `SDKMessageOrigin`, allowing consumers to distinguish user-prompted results from task-notification followups. Port of TypeScript SDK v0.2.126. ([#180](https://github.com/Flohs/claude-agent-sdk-go/issues/180))
+- `RequestID string` field on `AssistantMessage` and `ResultMessage` for end-to-end request tracing. `SubagentType string` and `TaskDescription string` fields on `TaskStartedMessage`, `TaskProgressMessage`, and `TaskNotificationMessage` for richer task event context. Port of TypeScript SDK v0.3.142. ([#181](https://github.com/Flohs/claude-agent-sdk-go/issues/181))
 
 ### Changed
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -104,6 +104,7 @@ func parseAssistantMessage(data map[string]any) (*AssistantMessage, error) {
 		SessionID:       stringField(data, "session_id"),
 		UUID:            stringField(data, "uuid"),
 		StopReason:      stringField(message, "stop_reason"),
+		RequestID:       stringField(data, "request_id"),
 	}
 
 	if errStr := stringField(data, "error"); errStr != "" {
@@ -136,27 +137,31 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 	switch subtype {
 	case "task_started":
 		return &TaskStartedMessage{
-			SystemMessage: base,
-			TaskID:        stringField(data, "task_id"),
-			Description:   stringField(data, "description"),
-			UUID:          stringField(data, "uuid"),
-			SessionID:     stringField(data, "session_id"),
-			ToolUseID:     stringField(data, "tool_use_id"),
-			TaskType:      stringField(data, "task_type"),
+			SystemMessage:   base,
+			TaskID:          stringField(data, "task_id"),
+			Description:     stringField(data, "description"),
+			UUID:            stringField(data, "uuid"),
+			SessionID:       stringField(data, "session_id"),
+			ToolUseID:       stringField(data, "tool_use_id"),
+			TaskType:        stringField(data, "task_type"),
+			SubagentType:    stringField(data, "subagent_type"),
+			TaskDescription: stringField(data, "task_description"),
 		}, nil
 
 	case "task_progress":
 		usage := parseTaskUsage(data["usage"])
 		return &TaskProgressMessage{
-			SystemMessage: base,
-			TaskID:        stringField(data, "task_id"),
-			Description:   stringField(data, "description"),
-			Usage:         usage,
-			UUID:          stringField(data, "uuid"),
-			SessionID:     stringField(data, "session_id"),
-			ToolUseID:     stringField(data, "tool_use_id"),
-			LastToolName:  stringField(data, "last_tool_name"),
-			Summary:       stringField(data, "summary"),
+			SystemMessage:   base,
+			TaskID:          stringField(data, "task_id"),
+			Description:     stringField(data, "description"),
+			Usage:           usage,
+			UUID:            stringField(data, "uuid"),
+			SessionID:       stringField(data, "session_id"),
+			ToolUseID:       stringField(data, "tool_use_id"),
+			LastToolName:    stringField(data, "last_tool_name"),
+			Summary:         stringField(data, "summary"),
+			SubagentType:    stringField(data, "subagent_type"),
+			TaskDescription: stringField(data, "task_description"),
 		}, nil
 
 	case "mirror_error":
@@ -182,15 +187,17 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 			usage = &tu
 		}
 		return &TaskNotificationMessage{
-			SystemMessage: base,
-			TaskID:        stringField(data, "task_id"),
-			Status:        TaskNotificationStatus(stringField(data, "status")),
-			OutputFile:    stringField(data, "output_file"),
-			Summary:       stringField(data, "summary"),
-			UUID:          stringField(data, "uuid"),
-			SessionID:     stringField(data, "session_id"),
-			ToolUseID:     stringField(data, "tool_use_id"),
-			Usage:         usage,
+			SystemMessage:   base,
+			TaskID:          stringField(data, "task_id"),
+			Status:          TaskNotificationStatus(stringField(data, "status")),
+			OutputFile:      stringField(data, "output_file"),
+			Summary:         stringField(data, "summary"),
+			UUID:            stringField(data, "uuid"),
+			SessionID:       stringField(data, "session_id"),
+			ToolUseID:       stringField(data, "tool_use_id"),
+			Usage:           usage,
+			SubagentType:    stringField(data, "subagent_type"),
+			TaskDescription: stringField(data, "task_description"),
 		}, nil
 
 	default:
@@ -209,6 +216,7 @@ func parseResultMessage(data map[string]any) (*ResultMessage, error) {
 		StopReason:     stringField(data, "stop_reason"),
 		TerminalReason: stringField(data, "terminal_reason"),
 		Origin:         stringField(data, "origin"),
+		RequestID:      stringField(data, "request_id"),
 		Result:         stringField(data, "result"),
 	}
 

--- a/types.go
+++ b/types.go
@@ -168,6 +168,8 @@ type AssistantMessage struct {
 	// StopReason is why the model stopped generating (e.g. "end_turn",
 	// "tool_use", "max_tokens"). Empty when not provided.
 	StopReason string `json:"stop_reason,omitempty"`
+	// RequestID is the API request identifier for this message.
+	RequestID string `json:"request_id,omitempty"`
 	// RawData contains the full raw message data for forward compatibility
 	// with fields not yet modeled by the SDK.
 	RawData map[string]any `json:"-"`
@@ -202,12 +204,16 @@ const (
 // TaskStartedMessage is emitted when a task starts.
 type TaskStartedMessage struct {
 	SystemMessage
-	TaskID      string `json:"task_id"`
-	Description string `json:"description"`
-	UUID        string `json:"uuid"`
-	SessionID   string `json:"session_id"`
-	ToolUseID   string `json:"tool_use_id,omitempty"`
-	TaskType    string `json:"task_type,omitempty"`
+	TaskID          string `json:"task_id"`
+	Description     string `json:"description"`
+	UUID            string `json:"uuid"`
+	SessionID       string `json:"session_id"`
+	ToolUseID       string `json:"tool_use_id,omitempty"`
+	TaskType        string `json:"task_type,omitempty"`
+	// SubagentType identifies the type of subagent that started this task.
+	SubagentType    string `json:"subagent_type,omitempty"`
+	// TaskDescription is a human-readable description of the task.
+	TaskDescription string `json:"task_description,omitempty"`
 }
 
 // TaskProgressMessage is emitted while a task is in progress.
@@ -223,6 +229,10 @@ type TaskProgressMessage struct {
 	// Summary is an AI-generated progress summary when AgentProgressSummaries
 	// is enabled in Options.
 	Summary string `json:"summary,omitempty"`
+	// SubagentType identifies the type of subagent that owns this task.
+	SubagentType string `json:"subagent_type,omitempty"`
+	// TaskDescription is a human-readable description of the task.
+	TaskDescription string `json:"task_description,omitempty"`
 }
 
 // TaskNotificationMessage is emitted when a task completes, fails, or is stopped.
@@ -236,6 +246,10 @@ type TaskNotificationMessage struct {
 	SessionID  string                 `json:"session_id"`
 	ToolUseID  string                 `json:"tool_use_id,omitempty"`
 	Usage      *TaskUsage             `json:"usage,omitempty"`
+	// SubagentType identifies the type of subagent that completed this task.
+	SubagentType string `json:"subagent_type,omitempty"`
+	// TaskDescription is a human-readable description of the completed task.
+	TaskDescription string `json:"task_description,omitempty"`
 }
 
 // MirrorErrorMessage is an SDK-synthesized system message emitted when the
@@ -276,7 +290,9 @@ type ResultMessage struct {
 	APIErrorStatus *int `json:"api_error_status,omitempty"`
 	// Origin forwards the triggering message's origin so consumers can
 	// distinguish user-prompted results from task-notification followups.
-	Origin           string         `json:"origin,omitempty"`
+	Origin string `json:"origin,omitempty"`
+	// RequestID is the API request identifier for the final API call.
+	RequestID        string         `json:"request_id,omitempty"`
 	TotalCostUSD     *float64       `json:"total_cost_usd,omitempty"`
 	Usage            map[string]any `json:"usage,omitempty"`
 	Result           string         `json:"result,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `RequestID string` field to `AssistantMessage` and `ResultMessage` for end-to-end request tracing
- Adds `SubagentType string` and `TaskDescription string` fields to `TaskStartedMessage`, `TaskProgressMessage`, and `TaskNotificationMessage` for richer task event context
- Port of TypeScript SDK v0.3.142

## Changes

- `types.go`: added `RequestID` to `AssistantMessage` and `ResultMessage`; added `SubagentType` and `TaskDescription` to all three task message types
- `message_parser.go`: parse new fields in `parseAssistantMessage()`, `parseResultMessage()`, and the three task message parsers
- `CHANGELOG.md`: updated `[Unreleased]` section

## Test plan

- [ ] Verify `AssistantMessage.RequestID` is populated from `request_id` in the JSON
- [ ] Verify `ResultMessage.RequestID` is populated from `request_id`
- [ ] Verify task messages include `SubagentType` and `TaskDescription` when present

Closes #181

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_