### PR TITLE
fix: suppress redundant ProcessError after is_error result (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - Panics inside user-supplied `Options.StderrCallback` functions are now recovered and logged, preventing a crashing callback from terminating the subprocess reader goroutine. Port of TypeScript SDK v0.3.144. ([#173](https://github.com/Flohs/claude-agent-sdk-go/issues/173))
+- `Query()` now surfaces a `*ProcessError` on the errors channel when the CLI subprocess exits with a non-zero code and no `is_error: true` result was already delivered. When an error result was delivered, the subprocess exit error is suppressed so callers don't receive both. Port of Python SDK v0.2.82. ([#174](https://github.com/Flohs/claude-agent-sdk-go/issues/174))
 
 
 ## [1.6.0] - 2026-04-27

--- a/claude.go
+++ b/claude.go
@@ -148,6 +148,11 @@ func Query(ctx context.Context, prompt string, opts *Options) (<-chan Message, <
 			}
 		}
 
+		// Surface a subprocess error only when no is_error result was already
+		// delivered, so callers don't see both the error result and a ProcessError.
+		if q.processError != nil {
+			errs <- q.processError
+		}
 		_ = q.close()
 	}()
 

--- a/query.go
+++ b/query.go
@@ -40,6 +40,14 @@ type query struct {
 	firstResultOnce        sync.Once
 	streamCloseTimeout     float64
 	excludeDynamicSections bool
+	// lastIsErrorResultDelivered is set when a result message with is_error:true
+	// has been delivered to messageCh. It suppresses ProcessError generation
+	// for subsequent subprocess exit failures so callers don't see both.
+	lastIsErrorResultDelivered bool
+	// processError is set when the subprocess exits with a non-zero code and
+	// no is_error result was delivered. Callers (e.g. Query) surface it after
+	// the message loop ends.
+	processError error
 
 	// Transcript mirror wiring. batcher is nil when Options.SessionStore is
 	// unset; when non-nil, transcript_mirror frames are peeled off the
@@ -342,6 +350,18 @@ func (q *query) readMessages() {
 			continue
 		}
 
+		// Subprocess exit error: suppress it if an is_error result was already
+		// delivered so callers don't see both. Otherwise record it so the
+		// caller (e.g. Query) can surface a ProcessError after the loop ends.
+		if msgType == "error" {
+			if !q.lastIsErrorResultDelivered {
+				errStr, _ := msg["error"].(string)
+				q.processError = &ProcessError{SDKError: SDKError{Message: errStr}}
+			}
+			// Don't forward to messageCh; the deferred "end" frame handles close.
+			continue
+		}
+
 		// Flush the batcher before yielding each result message so any
 		// entries emitted during the turn land in the store before the
 		// caller observes the result. Runs in a goroutine with a bounded
@@ -349,6 +369,9 @@ func (q *query) readMessages() {
 		if msgType == "result" {
 			q.flushBeforeResult()
 			q.firstResultOnce.Do(func() { close(q.firstResultCh) })
+			if isErr, _ := msg["is_error"].(bool); isErr {
+				q.lastIsErrorResultDelivered = true
+			}
 		}
 
 		// Regular SDK messages
@@ -677,9 +700,6 @@ func (q *query) receiveMessages() <-chan map[string]any {
 		for msg := range q.messageCh {
 			msgType, _ := msg["type"].(string)
 			if msgType == "end" {
-				break
-			}
-			if msgType == "error" {
 				break
 			}
 			select {


### PR DESCRIPTION
## Summary

- Tracks whether an `is_error` result has already been delivered to the caller
- When the Claude CLI subprocess exits with a non-zero code, only surfaces a `ProcessError` if no `is_error` result message was already received
- Prevents callers from receiving both a result message with `is_error: true` and a duplicate `ProcessError` for the same failure

## Test plan

- [ ] Verify that when Claude returns an `is_error` result, no `ProcessError` is sent on the errors channel
- [ ] Verify that when the subprocess exits non-zero without an `is_error` result, `ProcessError` is still surfaced
- [ ] Check existing tests pass

Closes #174

https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_