### PR TITLE
feat: enrich ToolPermissionContext with additional fields (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `Options.ForwardSubagentText bool` field forwarded as `--forward-subagent-text` to the CLI, enabling forwarding of subagent text messages to the parent session stream. Port of TypeScript SDK v0.3.130. ([#179](https://github.com/Flohs/claude-agent-sdk-go/issues/179))
 - `Origin string` field on `ResultMessage` that surfaces the triggering message's `SDKMessageOrigin`, allowing consumers to distinguish user-prompted results from task-notification followups. Port of TypeScript SDK v0.2.126. ([#180](https://github.com/Flohs/claude-agent-sdk-go/issues/180))
 - `RequestID string` field on `AssistantMessage` and `ResultMessage` for end-to-end request tracing. `SubagentType string` and `TaskDescription string` fields on `TaskStartedMessage`, `TaskProgressMessage`, and `TaskNotificationMessage` for richer task event context. Port of TypeScript SDK v0.3.142. ([#181](https://github.com/Flohs/claude-agent-sdk-go/issues/181))
+- `DecisionReason`, `BlockedPath`, `Title`, `DisplayName`, and `Description` fields on `ToolPermissionContext` for richer permission callback context. Permission suggestions are now fully parsed into typed `[]PermissionUpdate` values. Port of Python SDK v0.2.82. ([#176](https://github.com/Flohs/claude-agent-sdk-go/issues/176))
 
 ### Changed
 

--- a/permissions.go
+++ b/permissions.go
@@ -115,6 +115,48 @@ type ToolPermissionContext struct {
 	ToolUseID string
 	// AgentID is the ID of the sub-agent requesting permission, if applicable.
 	AgentID string
+	// DecisionReason is the CLI's suggested reason for this permission decision,
+	// if provided (e.g. "allow_once", "deny", "allow_rule").
+	DecisionReason string
+	// BlockedPath is the filesystem path that triggered a deny decision, if any.
+	BlockedPath string
+	// Title is the human-readable display title for this permission request.
+	Title string
+	// DisplayName is the tool's display name as shown in the permission UI.
+	DisplayName string
+	// Description is additional descriptive context for this permission request.
+	Description string
+}
+
+// parsePermissionUpdate converts a raw map from the CLI protocol into a
+// PermissionUpdate value.
+func parsePermissionUpdate(m map[string]any) PermissionUpdate {
+	p := PermissionUpdate{
+		Type:        PermissionUpdateType(stringField(m, "type")),
+		Behavior:    PermissionBehavior(stringField(m, "behavior")),
+		Mode:        PermissionMode(stringField(m, "mode")),
+		Destination: PermissionUpdateDestination(stringField(m, "destination")),
+	}
+	if rawRules, ok := m["rules"].([]any); ok {
+		p.Rules = make([]PermissionRuleValue, 0, len(rawRules))
+		for _, r := range rawRules {
+			if rm, ok := r.(map[string]any); ok {
+				p.Rules = append(p.Rules, PermissionRuleValue{
+					ToolName:    stringField(rm, "toolName"),
+					RuleContent: stringField(rm, "ruleContent"),
+				})
+			}
+		}
+	}
+	if rawDirs, ok := m["directories"].([]any); ok {
+		p.Directories = make([]string, 0, len(rawDirs))
+		for _, d := range rawDirs {
+			if s, ok := d.(string); ok {
+				p.Directories = append(p.Directories, s)
+			}
+		}
+	}
+	return p
 }
 
 // CanUseToolFunc is the callback type for tool permission decisions.

--- a/query.go
+++ b/query.go
@@ -497,13 +497,19 @@ func (q *query) handleCanUseTool(request map[string]any) (map[string]any, error)
 	originalInput := input
 
 	permCtx := ToolPermissionContext{
-		ToolUseID: stringField(request, "tool_use_id"),
-		AgentID:   stringField(request, "agent_id"),
+		ToolUseID:      stringField(request, "tool_use_id"),
+		AgentID:        stringField(request, "agent_id"),
+		DecisionReason: stringField(request, "decision_reason"),
+		BlockedPath:    stringField(request, "blocked_path"),
+		Title:          stringField(request, "title"),
+		DisplayName:    stringField(request, "display_name"),
+		Description:    stringField(request, "description"),
 	}
 	if suggestions, ok := request["permission_suggestions"].([]any); ok {
+		permCtx.Suggestions = make([]PermissionUpdate, 0, len(suggestions))
 		for _, s := range suggestions {
 			if sm, ok := s.(map[string]any); ok {
-				_ = sm // TODO: parse permission suggestions
+				permCtx.Suggestions = append(permCtx.Suggestions, parsePermissionUpdate(sm))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Added `DecisionReason`, `BlockedPath`, `Title`, `DisplayName`, `Description` fields to `ToolPermissionContext`
- Added `parsePermissionUpdate()` helper to properly convert raw permission suggestion maps into typed `[]PermissionUpdate`
- Brings `ToolPermissionContext` in line with the Python and TypeScript SDKs which expose these fields

## Test plan

- [ ] Verify `CanUseTool` callback receives populated `DecisionReason`, `BlockedPath`, `Title`, `DisplayName`, `Description` when CLI provides them
- [ ] Verify `Suggestions` slice is correctly typed as `[]PermissionUpdate` (not `[]any`)
- [ ] Check existing tests pass

Closes #176

https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w

---
_Generated by [Claude Code](https://claude.ai/code/session_016aQPBG9cDXWAzNo2z62E8w)_