### PR TITLE
chore: tests + docs + error-surfacing follow-ups from review (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@
 
 - Panics inside user-supplied `Options.StderrCallback` functions are now recovered and logged, preventing a crashing callback from terminating the subprocess reader goroutine. Port of TypeScript SDK v0.3.144. ([#173](https://github.com/Flohs/claude-agent-sdk-go/issues/173))
 - `Query()` now surfaces a `*ProcessError` on the errors channel when the CLI subprocess exits with a non-zero code and no `is_error: true` result was already delivered. When an error result was delivered, the subprocess exit error is suppressed so callers don't receive both. Port of Python SDK v0.2.82. ([#174](https://github.com/Flohs/claude-agent-sdk-go/issues/174))
+- `ResolveSettings` no longer silently swallows JSON parse errors. Corrupt `settings.json` files now surface a wrapped error identifying the source (`user` / `project` / `local`); invalid `ManagedSettings` JSON also returns an error since the caller explicitly opted in. File-not-found is still treated as a non-error skip. ([#204](https://github.com/Flohs/claude-agent-sdk-go/issues/204))
+
+### Documentation
+
+- `ImportSessionToStore`: added inline rationale for the `directory ...string` variadic signature, distinguishing it from the `*ViaStore` mutators that migrated to `StoreMutationOptions` in #162. The variadic is intentional here because `directory` is genuinely consumed to locate the on-disk JSONL source — the silent-discard foot-gun that motivated the v1.6.0 fix does not apply. ([#204](https://github.com/Flohs/claude-agent-sdk-go/issues/204))
+
+### Tests
+
+- Added coverage for the [Unreleased] additions: `ResolveSettings` (cascade, shallow merge, corrupt-file and managed-settings parse errors), `ImportSessionToStore` (main transcript, subagent transcripts, error paths, zero-arg variadic), the new message-parser fields on `AssistantMessage` and `ResultMessage` (`RequestID`, `Origin`, `APIErrorStatus`, `DeferredToolUse`) and on `TaskStartedMessage` / `TaskProgressMessage` / `TaskNotificationMessage` (`SubagentType`, `TaskDescription`), the `*ProcessError` suppression branch in the query loop, and the `parsePermissionUpdate` typed-parser helper. ([#204](https://github.com/Flohs/claude-agent-sdk-go/issues/204))
 
 
 ## [1.6.0] - 2026-04-27

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -730,3 +730,226 @@ func TestParseMessage_MirrorErrorMessage_NullKey(t *testing.T) {
 		t.Errorf("Error = %q", me.Error)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Coverage for [Unreleased] message-parser additions (#204):
+// AssistantMessage.RequestID, ResultMessage.Origin / RequestID /
+// APIErrorStatus / DeferredToolUse, TaskStartedMessage.SubagentType /
+// TaskDescription, TaskNotificationMessage.SubagentType / TaskDescription.
+// ---------------------------------------------------------------------------
+
+func TestParseMessage_AssistantMessage_RequestID(t *testing.T) {
+	data := map[string]any{
+		"type":       "assistant",
+		"session_id": "sess-1",
+		"request_id": "req_abc123",
+		"message": map[string]any{
+			"model":   "claude-opus-4-7",
+			"content": []any{map[string]any{"type": "text", "text": "ok"}},
+		},
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	asst := msg.(*AssistantMessage)
+	if asst.RequestID != "req_abc123" {
+		t.Errorf("RequestID = %q, want req_abc123", asst.RequestID)
+	}
+}
+
+func TestParseMessage_ResultMessage_Origin(t *testing.T) {
+	data := map[string]any{
+		"type":       "result",
+		"subtype":    "success",
+		"is_error":   false,
+		"session_id": "s",
+		"origin":     "task_notification",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := msg.(*ResultMessage)
+	if r.Origin != "task_notification" {
+		t.Errorf("Origin = %q, want task_notification", r.Origin)
+	}
+}
+
+func TestParseMessage_ResultMessage_RequestID(t *testing.T) {
+	data := map[string]any{
+		"type":       "result",
+		"subtype":    "success",
+		"is_error":   false,
+		"session_id": "s",
+		"request_id": "req_final_xyz",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := msg.(*ResultMessage)
+	if r.RequestID != "req_final_xyz" {
+		t.Errorf("RequestID = %q, want req_final_xyz", r.RequestID)
+	}
+}
+
+func TestParseMessage_ResultMessage_APIErrorStatus(t *testing.T) {
+	// is_error result carries an HTTP status (e.g. 429, 529).
+	data := map[string]any{
+		"type":             "result",
+		"subtype":          "error",
+		"is_error":         true,
+		"session_id":       "s",
+		"api_error_status": float64(429),
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := msg.(*ResultMessage)
+	if r.APIErrorStatus == nil {
+		t.Fatal("APIErrorStatus is nil")
+	}
+	if *r.APIErrorStatus != 429 {
+		t.Errorf("*APIErrorStatus = %d, want 429", *r.APIErrorStatus)
+	}
+}
+
+func TestParseMessage_ResultMessage_APIErrorStatus_Absent(t *testing.T) {
+	// Successful result: api_error_status not emitted by the CLI.
+	data := map[string]any{
+		"type":       "result",
+		"subtype":    "success",
+		"is_error":   false,
+		"session_id": "s",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := msg.(*ResultMessage)
+	if r.APIErrorStatus != nil {
+		t.Errorf("APIErrorStatus = %v, want nil when absent", *r.APIErrorStatus)
+	}
+}
+
+func TestParseMessage_ResultMessage_DeferredToolUse(t *testing.T) {
+	data := map[string]any{
+		"type":       "result",
+		"subtype":    "success",
+		"is_error":   false,
+		"session_id": "s",
+		"deferred_tool_use": map[string]any{
+			"tool_use_id": "tu_123",
+			"tool_name":   "Bash",
+			"tool_input":  map[string]any{"command": "rm -rf /tmp/x"},
+		},
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := msg.(*ResultMessage)
+	if r.DeferredToolUse == nil {
+		t.Fatal("DeferredToolUse is nil")
+	}
+	if r.DeferredToolUse.ToolUseID != "tu_123" {
+		t.Errorf("DeferredToolUse.ToolUseID = %q", r.DeferredToolUse.ToolUseID)
+	}
+	if r.DeferredToolUse.ToolName != "Bash" {
+		t.Errorf("DeferredToolUse.ToolName = %q", r.DeferredToolUse.ToolName)
+	}
+	if cmd, _ := r.DeferredToolUse.ToolInput["command"].(string); cmd != "rm -rf /tmp/x" {
+		t.Errorf("DeferredToolUse.ToolInput[command] = %v", r.DeferredToolUse.ToolInput["command"])
+	}
+}
+
+func TestParseMessage_ResultMessage_DeferredToolUse_Absent(t *testing.T) {
+	// Normal (non-defer) result: DeferredToolUse stays nil.
+	data := map[string]any{
+		"type":       "result",
+		"subtype":    "success",
+		"is_error":   false,
+		"session_id": "s",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := msg.(*ResultMessage)
+	if r.DeferredToolUse != nil {
+		t.Errorf("expected nil DeferredToolUse, got %+v", r.DeferredToolUse)
+	}
+}
+
+func TestParseMessage_TaskStarted_SubagentTypeAndDescription(t *testing.T) {
+	data := map[string]any{
+		"type":             "system",
+		"subtype":          "task_started",
+		"task_id":          "t1",
+		"description":      "Running task",
+		"uuid":             "u1",
+		"session_id":       "s1",
+		"subagent_type":    "general-purpose",
+		"task_description": "Find all callers of foo()",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	task := msg.(*TaskStartedMessage)
+	if task.SubagentType != "general-purpose" {
+		t.Errorf("SubagentType = %q, want general-purpose", task.SubagentType)
+	}
+	if task.TaskDescription != "Find all callers of foo()" {
+		t.Errorf("TaskDescription = %q", task.TaskDescription)
+	}
+}
+
+func TestParseMessage_TaskProgress_SubagentTypeAndDescription(t *testing.T) {
+	data := map[string]any{
+		"type":             "system",
+		"subtype":          "task_progress",
+		"task_id":          "t1",
+		"uuid":             "u1",
+		"session_id":       "s1",
+		"subagent_type":    "explore",
+		"task_description": "Explore the codebase",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p := msg.(*TaskProgressMessage)
+	if p.SubagentType != "explore" {
+		t.Errorf("SubagentType = %q, want explore", p.SubagentType)
+	}
+	if p.TaskDescription != "Explore the codebase" {
+		t.Errorf("TaskDescription = %q", p.TaskDescription)
+	}
+}
+
+func TestParseMessage_TaskNotification_SubagentTypeAndDescription(t *testing.T) {
+	data := map[string]any{
+		"type":             "system",
+		"subtype":          "task_notification",
+		"task_id":          "t1",
+		"status":           "completed",
+		"uuid":             "u1",
+		"session_id":       "s1",
+		"subagent_type":    "plan",
+		"task_description": "Plan the migration",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	n := msg.(*TaskNotificationMessage)
+	if n.SubagentType != "plan" {
+		t.Errorf("SubagentType = %q, want plan", n.SubagentType)
+	}
+	if n.TaskDescription != "Plan the migration" {
+		t.Errorf("TaskDescription = %q", n.TaskDescription)
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -484,3 +484,184 @@ func TestInitialize_ExcludeDynamicSections(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// ProcessError suppression branch (#204 follow-up for #174).
+// query.readMessages must NOT generate a ProcessError when an is_error result
+// was already delivered, but MUST generate one if the subprocess exits with
+// no prior is_error result.
+// ---------------------------------------------------------------------------
+
+func TestReadMessages_ProcessErrorSuppressedAfterIsErrorResult(t *testing.T) {
+	mt := newMockTransport()
+	q := newQuery(queryConfig{transport: mt})
+	q.start()
+
+	frames := []map[string]any{
+		// is_error result flips the suppression flag.
+		{"type": "result", "subtype": "error", "is_error": true, "session_id": "s"},
+		// Exit-error frame that follows must be suppressed.
+		{"type": "error", "error": "exit 1"},
+	}
+	go func() {
+		for _, f := range frames {
+			mt.messages <- f
+		}
+		_ = mt.Close()
+	}()
+
+	// Drain the message channel until it closes.
+	out := q.receiveMessages()
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				goto done
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for message channel to close")
+		}
+	}
+done:
+
+	if q.processError != nil {
+		t.Errorf("processError should be suppressed after is_error result, got: %v", q.processError)
+	}
+	_ = q.close()
+}
+
+func TestReadMessages_ProcessErrorSurfacedWhenNoIsErrorResult(t *testing.T) {
+	mt := newMockTransport()
+	q := newQuery(queryConfig{transport: mt})
+	q.start()
+
+	frames := []map[string]any{
+		// A normal (non-error) result first.
+		{"type": "result", "subtype": "success", "is_error": false, "session_id": "s"},
+		// Then the subprocess exits with an error frame: no prior is_error,
+		// so processError must capture it.
+		{"type": "error", "error": "exec failed: signal: killed"},
+	}
+	go func() {
+		for _, f := range frames {
+			mt.messages <- f
+		}
+		_ = mt.Close()
+	}()
+
+	out := q.receiveMessages()
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				goto done
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for message channel to close")
+		}
+	}
+done:
+
+	if q.processError == nil {
+		t.Fatal("processError should be set when no is_error result preceded the exit error")
+	}
+	if !strings.Contains(q.processError.Error(), "exec failed") {
+		t.Errorf("processError.Error() = %q, want it to include 'exec failed'", q.processError.Error())
+	}
+	if _, ok := q.processError.(*ProcessError); !ok {
+		t.Errorf("processError should be *ProcessError, got %T", q.processError)
+	}
+	_ = q.close()
+}
+
+// ---------------------------------------------------------------------------
+// parsePermissionUpdate coverage (#204 follow-up for #176): exercise each
+// PermissionUpdateType branch so the typed parsing path stays correct.
+// ---------------------------------------------------------------------------
+
+func TestParsePermissionUpdate_AddRules(t *testing.T) {
+	in := map[string]any{
+		"type":     "addRules",
+		"behavior": "allow",
+		"rules": []any{
+			map[string]any{"toolName": "Bash", "ruleContent": "ls *"},
+			map[string]any{"toolName": "Read"},
+		},
+		"destination": "session",
+	}
+	p := parsePermissionUpdate(in)
+	if p.Type != PermissionUpdateAddRules {
+		t.Errorf("Type = %q", p.Type)
+	}
+	if p.Behavior != "allow" {
+		t.Errorf("Behavior = %q", p.Behavior)
+	}
+	if p.Destination != PermissionUpdateDestSession {
+		t.Errorf("Destination = %q", p.Destination)
+	}
+	if len(p.Rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(p.Rules))
+	}
+	if p.Rules[0].ToolName != "Bash" || p.Rules[0].RuleContent != "ls *" {
+		t.Errorf("Rules[0] = %+v", p.Rules[0])
+	}
+	if p.Rules[1].ToolName != "Read" || p.Rules[1].RuleContent != "" {
+		t.Errorf("Rules[1] = %+v", p.Rules[1])
+	}
+}
+
+func TestParsePermissionUpdate_SetMode(t *testing.T) {
+	in := map[string]any{
+		"type": "setMode",
+		"mode": "acceptEdits",
+	}
+	p := parsePermissionUpdate(in)
+	if p.Type != PermissionUpdateSetMode {
+		t.Errorf("Type = %q", p.Type)
+	}
+	if p.Mode != PermissionMode("acceptEdits") {
+		t.Errorf("Mode = %q", p.Mode)
+	}
+}
+
+func TestParsePermissionUpdate_AddDirectories(t *testing.T) {
+	in := map[string]any{
+		"type":        "addDirectories",
+		"directories": []any{"/a", "/b", "/c"},
+	}
+	p := parsePermissionUpdate(in)
+	if p.Type != PermissionUpdateAddDirectories {
+		t.Errorf("Type = %q", p.Type)
+	}
+	if len(p.Directories) != 3 || p.Directories[0] != "/a" || p.Directories[2] != "/c" {
+		t.Errorf("Directories = %v", p.Directories)
+	}
+}
+
+func TestParsePermissionUpdate_IgnoresNonStringDirectoryEntries(t *testing.T) {
+	// Defensive: directories array could contain mixed types under a buggy CLI.
+	in := map[string]any{
+		"type":        "addDirectories",
+		"directories": []any{"/a", 42, "/c"},
+	}
+	p := parsePermissionUpdate(in)
+	if len(p.Directories) != 2 {
+		t.Errorf("expected 2 valid string directories, got %v", p.Directories)
+	}
+}
+
+func TestParsePermissionUpdate_IgnoresNonMapRuleEntries(t *testing.T) {
+	in := map[string]any{
+		"type": "addRules",
+		"rules": []any{
+			map[string]any{"toolName": "Bash"},
+			"not-a-map", // should be skipped without panic.
+		},
+	}
+	p := parsePermissionUpdate(in)
+	if len(p.Rules) != 1 {
+		t.Errorf("expected 1 valid rule, got %v", p.Rules)
+	}
+}

--- a/sessions.go
+++ b/sessions.go
@@ -2171,6 +2171,16 @@ func ForkSessionViaStore(ctx context.Context, store SessionStore, sessionID, new
 //
 // Returns an error if the session file cannot be found, read, or if any
 // store write fails. Partial writes are possible if an error occurs mid-import.
+//
+// API shape note (do not migrate to StoreMutationOptions): the variadic
+// `directory ...string` mirrors the filesystem-helper convention used by
+// [DeleteSession], [ForkSession], and [GetSessionInfo]. This is intentionally
+// different from the `*ViaStore` mutators (RenameSessionViaStore, etc.) which
+// take a [StoreMutationOptions] struct: that switch was made in #162 because
+// the directory argument on those mutators was silently discarded by the
+// store write path — a foot-gun that does not apply here. ImportSessionToStore
+// genuinely consumes `directory` to locate the on-disk JSONL source before
+// any store write happens, so the variadic remains the correct shape.
 func ImportSessionToStore(ctx context.Context, store SessionStore, sessionID string, directory ...string) error {
 	if store == nil {
 		return fmt.Errorf("session store is nil")

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -3778,3 +3778,136 @@ func TestForkSessionViaStore_NilStoreErrors(t *testing.T) {
 		t.Fatal("expected error for nil store")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ImportSessionToStore tests (#204 follow-up for #184)
+// ---------------------------------------------------------------------------
+
+func TestImportSessionToStore_MainTranscriptOnly(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/import-main")
+	sessionID := testUUID1
+
+	content := strings.Join([]string{
+		makeUserLine("u1", "", "Hello"),
+		makeAssistantLine("a1", "u1", "Hi"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, content)
+
+	store := NewInMemorySessionStore()
+	if err := ImportSessionToStore(context.Background(), store, sessionID, "/test/import-main"); err != nil {
+		t.Fatalf("ImportSessionToStore: %v", err)
+	}
+
+	// Verify both lines landed under the derived SessionKey.
+	key := SessionKey{
+		ProjectKey: sanitizePath("/test/import-main"),
+		SessionID:  sessionID,
+	}
+	entries, err := store.Load(context.Background(), key)
+	if err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+	if entries[0]["type"] != "user" || entries[1]["type"] != "assistant" {
+		t.Errorf("entry order/type mismatch: %+v", entries)
+	}
+}
+
+func TestImportSessionToStore_IncludesSubagentTranscripts(t *testing.T) {
+	projDir := setupTestProjectDir(t, "/test/import-sub")
+	sessionID := testUUID1
+	mainContent := strings.Join([]string{
+		makeUserLine("u1", "", "Hello"),
+	}, "\n") + "\n"
+	writeSessionFile(t, projDir, sessionID, mainContent)
+
+	// Subagent transcripts live under <session_id>/subagents/agent-<id>.jsonl.
+	subDir := filepath.Join(projDir, sessionID, "subagents")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentLine := makeAssistantLine("agA-msg1", "", "subagent reply")
+	if err := os.WriteFile(filepath.Join(subDir, "agent-alpha.jsonl"), []byte(agentLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewInMemorySessionStore()
+	if err := ImportSessionToStore(context.Background(), store, sessionID, "/test/import-sub"); err != nil {
+		t.Fatalf("ImportSessionToStore: %v", err)
+	}
+
+	// Main transcript landed.
+	mainKey := SessionKey{
+		ProjectKey: sanitizePath("/test/import-sub"),
+		SessionID:  sessionID,
+	}
+	mainEntries, err := store.Load(context.Background(), mainKey)
+	if err != nil || len(mainEntries) != 1 {
+		t.Fatalf("main transcript: err=%v entries=%v", err, mainEntries)
+	}
+
+	// Subagent transcript landed under the subagents/agent-<id> subkey.
+	subKey := SessionKey{
+		ProjectKey: sanitizePath("/test/import-sub"),
+		SessionID:  sessionID,
+		Subpath:    "subagents/agent-alpha",
+	}
+	subEntries, err := store.Load(context.Background(), subKey)
+	if err != nil {
+		t.Fatalf("subagent Load: %v", err)
+	}
+	if len(subEntries) != 1 {
+		t.Fatalf("expected 1 subagent entry, got %d: %+v", len(subEntries), subEntries)
+	}
+}
+
+func TestImportSessionToStore_InvalidUUIDErrors(t *testing.T) {
+	store := NewInMemorySessionStore()
+	err := ImportSessionToStore(context.Background(), store, "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+	if !strings.Contains(err.Error(), "invalid session ID") {
+		t.Errorf("expected 'invalid session ID' message, got: %v", err)
+	}
+}
+
+func TestImportSessionToStore_NilStoreErrors(t *testing.T) {
+	err := ImportSessionToStore(context.Background(), nil, testUUID1)
+	if err == nil {
+		t.Fatal("expected error for nil store")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Errorf("expected nil-store message, got: %v", err)
+	}
+}
+
+func TestImportSessionToStore_SessionNotFoundErrors(t *testing.T) {
+	// CLAUDE_CONFIG_DIR is set to an empty temp dir; no session files exist.
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	store := NewInMemorySessionStore()
+	err := ImportSessionToStore(context.Background(), store, testUUID1)
+	if err == nil {
+		t.Fatal("expected error when session file is missing")
+	}
+	if !strings.Contains(err.Error(), "session not found") {
+		t.Errorf("expected 'session not found' message, got: %v", err)
+	}
+}
+
+func TestImportSessionToStore_VariadicDirectoryAcceptsZeroArgs(t *testing.T) {
+	// Locks in the variadic shape called out in the inline doc comment on
+	// ImportSessionToStore: the function must accept zero directory args and
+	// search all projects. If someone later switches to a non-variadic
+	// signature this test will fail to compile.
+	projDir := setupTestProjectDir(t, "/test/import-zero-args")
+	sessionID := testUUID1
+	writeSessionFile(t, projDir, sessionID, makeUserLine("u1", "", "hi")+"\n")
+
+	store := NewInMemorySessionStore()
+	if err := ImportSessionToStore(context.Background(), store, sessionID); err != nil {
+		t.Fatalf("ImportSessionToStore with no directory arg: %v", err)
+	}
+}

--- a/settings_resolve.go
+++ b/settings_resolve.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -86,7 +87,14 @@ func ResolveSettings(opts *ResolveSettingsOptions) (*ResolvedSettings, error) {
 
 	for _, src := range sources {
 		m, err := readSettingsFile(src.path)
-		if err != nil || m == nil {
+		if err != nil {
+			// File exists but is unreadable or contains invalid JSON.
+			// Surface this — a corrupt settings file is a real user-facing
+			// bug, not something to silently skip. readSettingsFile returns
+			// (nil, nil) for ENOENT, which is the path that falls through.
+			return nil, fmt.Errorf("reading %s settings (%s): %w", src.name, src.path, err)
+		}
+		if m == nil {
 			continue
 		}
 		result.BySource[src.name] = m
@@ -95,10 +103,16 @@ func ResolveSettings(opts *ResolveSettingsOptions) (*ResolvedSettings, error) {
 		}
 	}
 
-	// Managed settings have the highest precedence.
+	// Managed settings have the highest precedence. Parse errors here are
+	// returned because the caller explicitly opted in by passing a non-empty
+	// ManagedSettings string — silently dropping their input would mask a bug
+	// in whatever produced the JSON.
 	if opts.ManagedSettings != "" {
 		m, err := parseSettingsJSON(opts.ManagedSettings)
-		if err == nil && m != nil {
+		if err != nil {
+			return nil, fmt.Errorf("parsing managed settings: %w", err)
+		}
+		if m != nil {
 			result.BySource["managed"] = m
 			for k, v := range m {
 				result.Merged[k] = v

--- a/settings_resolve_test.go
+++ b/settings_resolve_test.go
@@ -1,0 +1,222 @@
+package claude
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile is a small test helper that writes content to a path, creating
+// parent directories. Mirrors the style used in sessions_test.go.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestResolveSettings_NilOpts(t *testing.T) {
+	// With nil opts, ConfigDir/Cwd fall back to defaults; no panic.
+	r, err := ResolveSettings(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil ResolvedSettings")
+	}
+	if r.Merged == nil || r.BySource == nil {
+		t.Fatal("expected initialized maps even when no sources present")
+	}
+}
+
+func TestResolveSettings_EmptyDirs(t *testing.T) {
+	// All sources absent: returns initialized but empty result, no error.
+	r, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir: t.TempDir(),
+		Cwd:       t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(r.Merged) != 0 {
+		t.Errorf("Merged should be empty, got %v", r.Merged)
+	}
+	if len(r.BySource) != 0 {
+		t.Errorf("BySource should be empty, got %v", r.BySource)
+	}
+}
+
+func TestResolveSettings_UserOnly(t *testing.T) {
+	cfg := t.TempDir()
+	writeFile(t, filepath.Join(cfg, "settings.json"), `{"theme": "dark", "model": "opus"}`)
+
+	r, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir: cfg,
+		Cwd:       t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.Merged["theme"] != "dark" {
+		t.Errorf("Merged[theme] = %v, want dark", r.Merged["theme"])
+	}
+	if r.Merged["model"] != "opus" {
+		t.Errorf("Merged[model] = %v, want opus", r.Merged["model"])
+	}
+	if _, ok := r.BySource["user"]; !ok {
+		t.Error("BySource[user] missing")
+	}
+	if _, ok := r.BySource["project"]; ok {
+		t.Error("BySource[project] should not be present")
+	}
+}
+
+func TestResolveSettings_Cascade(t *testing.T) {
+	// Precedence (low → high): user → project → local → managed.
+	// Each layer overrides matching top-level keys.
+	cfg := t.TempDir()
+	cwd := t.TempDir()
+
+	writeFile(t, filepath.Join(cfg, "settings.json"), `{"theme": "user", "from_user": true}`)
+	writeFile(t, filepath.Join(cwd, ".claude", "settings.json"), `{"theme": "project", "from_project": true}`)
+	writeFile(t, filepath.Join(cwd, ".claude", "settings.local.json"), `{"theme": "local", "from_local": true}`)
+
+	r, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir:       cfg,
+		Cwd:             cwd,
+		ManagedSettings: `{"theme": "managed", "from_managed": true}`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Highest precedence wins for the conflicting key.
+	if r.Merged["theme"] != "managed" {
+		t.Errorf("Merged[theme] = %v, want managed", r.Merged["theme"])
+	}
+	// Non-conflicting keys from each layer are preserved.
+	for _, k := range []string{"from_user", "from_project", "from_local", "from_managed"} {
+		if r.Merged[k] != true {
+			t.Errorf("Merged[%s] = %v, want true", k, r.Merged[k])
+		}
+	}
+	// BySource keeps each layer's raw values intact (theme should still read
+	// "user" in the user-source map even though merged is "managed").
+	if r.BySource["user"]["theme"] != "user" {
+		t.Errorf("BySource[user][theme] = %v, want user", r.BySource["user"]["theme"])
+	}
+	if r.BySource["project"]["theme"] != "project" {
+		t.Errorf("BySource[project][theme] = %v, want project", r.BySource["project"]["theme"])
+	}
+	if r.BySource["local"]["theme"] != "local" {
+		t.Errorf("BySource[local][theme] = %v, want local", r.BySource["local"]["theme"])
+	}
+	if r.BySource["managed"]["theme"] != "managed" {
+		t.Errorf("BySource[managed][theme] = %v, want managed", r.BySource["managed"]["theme"])
+	}
+}
+
+func TestResolveSettings_CorruptUserFileReturnsError(t *testing.T) {
+	// Regression: an existing-but-corrupt settings file used to be silently
+	// skipped. After the issue #204 fix it must surface as an error so the
+	// caller can act on it.
+	cfg := t.TempDir()
+	writeFile(t, filepath.Join(cfg, "settings.json"), `{ not valid json `)
+
+	_, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir: cfg,
+		Cwd:       t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error for corrupt user settings.json, got nil")
+	}
+	if !strings.Contains(err.Error(), "user settings") {
+		t.Errorf("error should identify the source (user), got: %v", err)
+	}
+}
+
+func TestResolveSettings_CorruptProjectFileReturnsError(t *testing.T) {
+	cwd := t.TempDir()
+	writeFile(t, filepath.Join(cwd, ".claude", "settings.json"), `[invalid]`)
+
+	_, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir: t.TempDir(),
+		Cwd:       cwd,
+	})
+	if err == nil {
+		t.Fatal("expected error for corrupt project settings.json, got nil")
+	}
+	if !strings.Contains(err.Error(), "project settings") {
+		t.Errorf("error should identify the source (project), got: %v", err)
+	}
+}
+
+func TestResolveSettings_InvalidManagedJSONReturnsError(t *testing.T) {
+	// Caller explicitly opted in by passing ManagedSettings — silently
+	// dropping the input would mask a bug in whatever produced the JSON.
+	_, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir:       t.TempDir(),
+		Cwd:             t.TempDir(),
+		ManagedSettings: `{"unterminated":`,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid ManagedSettings JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "managed settings") {
+		t.Errorf("error should mention managed settings, got: %v", err)
+	}
+	// Underlying json.SyntaxError should be wrapped, so errors.As can reach it.
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Errorf("expected wrapped *json.SyntaxError, got: %v", err)
+	}
+}
+
+func TestResolveSettings_EmptyManagedSettingsIsNotAnError(t *testing.T) {
+	// Empty string means "no managed source provided" — the dominant case.
+	r, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir:       t.TempDir(),
+		Cwd:             t.TempDir(),
+		ManagedSettings: "",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := r.BySource["managed"]; ok {
+		t.Error("BySource[managed] should be absent when ManagedSettings is empty")
+	}
+}
+
+func TestResolveSettings_ShallowMerge(t *testing.T) {
+	// Top-level keys are replaced wholesale; nested objects are NOT deep-merged.
+	// This documents the contract called out in the GoDoc.
+	cfg := t.TempDir()
+	cwd := t.TempDir()
+	writeFile(t, filepath.Join(cfg, "settings.json"), `{"nested": {"a": 1, "b": 2}}`)
+	writeFile(t, filepath.Join(cwd, ".claude", "settings.json"), `{"nested": {"c": 3}}`)
+
+	r, err := ResolveSettings(&ResolveSettingsOptions{
+		ConfigDir: cfg,
+		Cwd:       cwd,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	nested, ok := r.Merged["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("Merged[nested] is not a map: %T", r.Merged["nested"])
+	}
+	// Project replaces user's nested object entirely — user's "a"/"b" are gone.
+	if _, hasA := nested["a"]; hasA {
+		t.Errorf("expected shallow merge to drop user keys; got nested[a] still present: %v", nested)
+	}
+	if nested["c"] != float64(3) {
+		t.Errorf("nested[c] = %v, want 3", nested["c"])
+	}
+}


### PR DESCRIPTION
Closes #204

## Summary

Three follow-ups from an internal review of the `[Unreleased]` changes since v1.6.0.

1. **Tests** — the `[Unreleased]` window added ~600 LOC with zero new test coverage. This adds 25 new tests across 4 files:
   - `settings_resolve_test.go` (new): cascade ordering, shallow-merge contract, corrupt-file errors, invalid `ManagedSettings`, empty-managed-not-error, nil-opts, empty dirs.
   - `message_parser_test.go`: `AssistantMessage.RequestID`; `ResultMessage` `Origin` / `RequestID` / `APIErrorStatus` (+ absent); `DeferredToolUse` (+ absent); `SubagentType` and `TaskDescription` on `TaskStarted`/`TaskProgress`/`TaskNotification`.
   - `query_test.go`: `*ProcessError` suppression branch (suppressed after `is_error` result; surfaced when no prior `is_error`); `parsePermissionUpdate` typed parsing across `addRules` / `setMode` / `addDirectories` + defensive paths for non-string directory entries and non-map rule entries.
   - `sessions_test.go`: `ImportSessionToStore` main transcript, subagent transcripts, invalid-UUID, nil-store, session-not-found, and a zero-arg variadic shape lock-in.
2. **`ImportSessionToStore` rationale comment** — explains why this function keeps `directory ...string` instead of migrating to `StoreMutationOptions` like the `*ViaStore` mutators did in #162. The silent-discard foot-gun that motivated the v1.6.0 fix doesn't apply here because the directory is genuinely consumed to locate the on-disk JSONL source. The comment is there so a future automated reviewer doesn't re-flag the signature as inconsistent.
3. **`ResolveSettings` error surfacing** — function returned `(*ResolvedSettings, error)` but never produced a non-nil error. Corrupt user/project/local settings files now surface a wrapped error identifying the source; invalid `ManagedSettings` JSON also surfaces since the caller explicitly opted in. File-not-found stays a non-error skip.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] Unit tests pass
- [x] Race detection clean
- [x] go vet clean