### PR TITLE
feat: add McpServerConnectionStatusRequesting constant (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `McpServerConnectionStatusRequesting` (`"requesting"`) constant for the `McpServerConnectionStatus` type, covering the CLI state while it is actively authenticating or connecting to a remote MCP server. Port of TypeScript SDK v0.2.108. ([#206](https://github.com/Flohs/claude-agent-sdk-go/issues/206))
+
 ## [2.0.0] - 2026-05-19
 
 This release lands a broad set of parity ports from the Python and TypeScript

--- a/mcp.go
+++ b/mcp.go
@@ -100,11 +100,12 @@ func (c McpSdkServerConfig) MarshalJSON() ([]byte, error) {
 type McpServerConnectionStatus string
 
 const (
-	McpServerConnectionStatusConnected McpServerConnectionStatus = "connected"
-	McpServerConnectionStatusFailed    McpServerConnectionStatus = "failed"
-	McpServerConnectionStatusNeedsAuth McpServerConnectionStatus = "needs-auth"
-	McpServerConnectionStatusPending   McpServerConnectionStatus = "pending"
-	McpServerConnectionStatusDisabled  McpServerConnectionStatus = "disabled"
+	McpServerConnectionStatusConnected  McpServerConnectionStatus = "connected"
+	McpServerConnectionStatusFailed     McpServerConnectionStatus = "failed"
+	McpServerConnectionStatusNeedsAuth  McpServerConnectionStatus = "needs-auth"
+	McpServerConnectionStatusPending    McpServerConnectionStatus = "pending"
+	McpServerConnectionStatusRequesting McpServerConnectionStatus = "requesting"
+	McpServerConnectionStatusDisabled   McpServerConnectionStatus = "disabled"
 )
 
 // McpToolAnnotations contains tool annotations from MCP server status.


### PR DESCRIPTION
## Summary

- Adds `McpServerConnectionStatusRequesting` (`"requesting"`) to the `McpServerConnectionStatus` type
- Port of TypeScript SDK v0.2.108

## Changes

`mcp.go` — one new constant after `McpServerConnectionStatusPending`:
```go
McpServerConnectionStatusRequesting McpServerConnectionStatus = "requesting"
```

`CHANGELOG.md` — new `[Unreleased]` section documenting the addition.

## Context

The CLI emits `status: "requesting"` while it is actively authenticating or connecting to a remote MCP server (the state between `"pending"` and `"connected"`/`"failed"`). Without this constant, callers comparing `McpServerStatus.Status` against typed values would miss this intermediate state.

Closes #206

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWU4hQcyHdmGKvmQijxEUA)_