### PR TITLE
feat: add PermissionPolicy field to remote MCP server configs (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `McpServerConnectionStatusRequesting` (`"requesting"`) constant for the `McpServerConnectionStatus` type, covering the CLI state while it is actively authenticating or connecting to a remote MCP server. Port of TypeScript SDK v0.2.108. ([#206](https://github.com/Flohs/claude-agent-sdk-go/issues/206))
+- `PermissionPolicy map[string]string` field on `McpSSEServerConfig` and `McpHTTPServerConfig` for per-tool permission policies. Keys are tool names; values are `"allow"`, `"ask"`, or `"deny"`. Forwarded to the CLI via the `--mcp-config` JSON blob so the CLI applies the policy to session allow/deny rules without requiring a `CanUseTool` callback. Port of TypeScript SDK v0.2.111. ([#208](https://github.com/Flohs/claude-agent-sdk-go/issues/208))
 
 ## [2.0.0] - 2026-05-19
 

--- a/mcp.go
+++ b/mcp.go
@@ -37,6 +37,9 @@ func (c McpStdioServerConfig) MarshalJSON() ([]byte, error) {
 type McpSSEServerConfig struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
+	// PermissionPolicy sets per-tool permission decisions for this server.
+	// Keys are tool names; values are "allow", "ask", or "deny".
+	PermissionPolicy map[string]string `json:"permissionPolicy,omitempty"`
 }
 
 func (McpSSEServerConfig) mcpServerConfigMarker() {}
@@ -57,6 +60,9 @@ func (c McpSSEServerConfig) MarshalJSON() ([]byte, error) {
 type McpHTTPServerConfig struct {
 	URL     string            `json:"url"`
 	Headers map[string]string `json:"headers,omitempty"`
+	// PermissionPolicy sets per-tool permission decisions for this server.
+	// Keys are tool names; values are "allow", "ask", or "deny".
+	PermissionPolicy map[string]string `json:"permissionPolicy,omitempty"`
 }
 
 func (McpHTTPServerConfig) mcpServerConfigMarker() {}


### PR DESCRIPTION
## Summary

- Adds `PermissionPolicy map[string]string` to `McpSSEServerConfig` and `McpHTTPServerConfig`
- Port of TypeScript SDK v0.2.111

## Changes

`mcp.go` — new field on both remote server config types:
```go
// PermissionPolicy sets per-tool permission decisions for this server.
// Keys are tool names; values are "allow", "ask", or "deny".
PermissionPolicy map[string]string `json:"permissionPolicy,omitempty"`
```

The existing `MarshalJSON` struct-alias pattern picks up the new field automatically — no marshaling code changes needed.

## Usage

```go
claude.Options{
    McpServers: map[string]claude.McpServerConfig{
        "my-server": claude.McpHTTPServerConfig{
            URL: "https://example.com/mcp",
            PermissionPolicy: map[string]string{
                "dangerous_tool": "ask",
                "safe_read_tool": "allow",
            },
        },
    },
}
```

The CLI applies the policy to session allow/deny rules, eliminating the need for a `CanUseTool` callback for predictable tool sets.

Closes #208

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWU4hQcyHdmGKvmQijxEUA)_