### PR TITLE
feat: add Client.AppendMessage for shouldQuery:false user messages (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `McpServerConnectionStatusRequesting` (`"requesting"`) constant for the `McpServerConnectionStatus` type, covering the CLI state while it is actively authenticating or connecting to a remote MCP server. Port of TypeScript SDK v0.2.108. ([#206](https://github.com/Flohs/claude-agent-sdk-go/issues/206))
 - `PermissionPolicy map[string]string` field on `McpSSEServerConfig` and `McpHTTPServerConfig` for per-tool permission policies. Keys are tool names; values are `"allow"`, `"ask"`, or `"deny"`. Forwarded to the CLI via the `--mcp-config` JSON blob so the CLI applies the policy to session allow/deny rules without requiring a `CanUseTool` callback. Port of TypeScript SDK v0.2.111. ([#208](https://github.com/Flohs/claude-agent-sdk-go/issues/208))
+- `Client.AppendMessage(ctx, content)` method that enqueues a user message with `shouldQuery: false`, appending it to the conversation context without triggering an assistant response turn. Useful for injecting context (tool results, background information) into a session before the next `SendQuery` call. Requires CLI >= v2.1.110. Port of TypeScript SDK v0.2.110. ([#209](https://github.com/Flohs/claude-agent-sdk-go/issues/209))
 
 ## [2.0.0] - 2026-05-19
 

--- a/client.go
+++ b/client.go
@@ -187,6 +187,44 @@ func (c *Client) SendQueryWithContent(ctx context.Context, content any) error {
 	return c.transport.Write(string(data) + "\n")
 }
 
+// AppendMessage enqueues a user message without triggering an assistant
+// response turn. The message is added to the conversation context and will
+// be visible as prior history on the next SendQuery call.
+//
+// Use this to inject context — tool results, system notes, or background
+// information — into an ongoing session before the next interactive turn.
+//
+// Requires CLI >= v2.1.110.
+func (c *Client) AppendMessage(ctx context.Context, content any) error {
+	if c.q == nil || c.transport == nil {
+		return &ConnectionError{SDKError: SDKError{Message: "Not connected. Call Connect() first."}}
+	}
+
+	if !c.transport.IsReady() {
+		return &ConnectionError{SDKError: SDKError{Message: "Transport is not ready. The subprocess may have exited."}}
+	}
+
+	switch content.(type) {
+	case string:
+		// ok
+	case []any:
+		// ok
+	default:
+		return &SDKError{Message: fmt.Sprintf("content must be a string or []any, got %T", content)}
+	}
+
+	message := map[string]any{
+		"type":               "user",
+		"message":            map[string]any{"role": "user", "content": content},
+		"parent_tool_use_id": nil,
+		"session_id":         "default",
+		"shouldQuery":        false,
+	}
+
+	data, _ := json.Marshal(message)
+	return c.transport.Write(string(data) + "\n")
+}
+
 // ReceiveMessages returns a channel of all messages from Claude.
 func (c *Client) ReceiveMessages(ctx context.Context) <-chan Message {
 	out := make(chan Message, 100)


### PR DESCRIPTION
## Summary

- Adds `Client.AppendMessage(ctx, content)` method that sends a user message with `shouldQuery: false`
- Port of TypeScript SDK v0.2.110

## Changes

`client.go` — new method after `SendQueryWithContent`:
```go
func (c *Client) AppendMessage(ctx context.Context, content any) error
```

Sends the wire message:
```json
{
  "type": "user",
  "message": {"role": "user", "content": "..."},
  "shouldQuery": false,
  "session_id": "default"
}
```

## Usage

```go
// Inject context before the next query without burning a turn
client.AppendMessage(ctx, "Here is the file content: " + fileContent)
client.SendQuery(ctx, "Now summarize it.")
```

Requires CLI >= v2.1.110.

Closes #209

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWU4hQcyHdmGKvmQijxEUA)_