### PR TITLE
fix: extractCreatedAtFromHead scans all head lines for timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `extractCreatedAtFromHead` now scans all lines in the head buffer when looking for a `timestamp` field, instead of stopping at the first valid JSON entry that happens to lack one. `ListSessions` and `GetSessionInfo` previously returned `CreatedAt: nil` for sessions whose first JSONL record was a metadata/summary entry without a `timestamp` key. Port of Python SDK v0.1.74 PR #907. ([#220](https://github.com/Flohs/claude-agent-sdk-go/issues/220))
 - `transcriptMirrorBatcher`: eliminated a `send on closed channel` race between `Enqueue` and `CloseContext`. The flush-request channel send in `Enqueue` and the channel close in `CloseContext` now both occur while holding the batcher mutex, making concurrent calls safe. The race was benign in normal SDK use (message-reader exits before `CloseContext` runs) but would panic in tests or embedders that exercise both concurrently. ([#221](https://github.com/Flohs/claude-agent-sdk-go/issues/221))
 
 ### Added

--- a/sessions.go
+++ b/sessions.go
@@ -1263,8 +1263,7 @@ func extractCreatedAtFromHead(head string) *int64 {
 			ms := int64(ts)
 			return &ms
 		}
-		// Only check the first valid JSON line
-		return nil
+		// No timestamp on this entry — keep scanning.
 	}
 	return nil
 }

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -2584,6 +2584,24 @@ func TestExtractCreatedAtFromHead_NoTimestamp(t *testing.T) {
 	}
 }
 
+func TestExtractCreatedAtFromHead_TimestampOnSecondLine(t *testing.T) {
+	// Regression: first JSON entry lacks "timestamp"; second entry has it.
+	// The function must continue scanning instead of returning nil early.
+	head := strings.Join([]string{
+		`{"type":"summary","content":"session metadata without timestamp"}`,
+		`{"type":"user","uuid":"u1","timestamp":"2025-01-15T10:30:00.000Z","message":{"role":"user","content":"Hello"}}`,
+		`{"type":"assistant","uuid":"a1","message":{"role":"assistant","content":"Hi"}}`,
+	}, "\n") + "\n"
+	result := extractCreatedAtFromHead(head)
+	if result == nil {
+		t.Fatal("expected non-nil CreatedAt when timestamp is on second line")
+	}
+	expected := int64(1736937000000) // 2025-01-15T10:30:00.000Z
+	if *result != expected {
+		t.Errorf("expected %d, got %d", expected, *result)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DeleteSession
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #220

## Summary

- Removes the `return nil` guard that caused `extractCreatedAtFromHead` to stop at the first valid JSON entry lacking a `timestamp` field — the loop now continues scanning all lines in the head buffer.
- Adds `TestExtractCreatedAtFromHead_TimestampOnSecondLine` regression test.

## Root cause

`extractCreatedAtFromHead` in `sessions.go` had an early `return nil` after parsing the first valid JSON entry. If that entry had no `timestamp` key (e.g. a `{"type":"summary",...}` metadata line), the function returned `nil` without looking at subsequent lines — even though a timestamp would have been found just one line later.

## Impact

`ListSessions` and `GetSessionInfo` returned `CreatedAt: nil` for sessions whose first JSONL record is a metadata/summary entry without a `timestamp` key.

## Port

Python SDK v0.1.74 PR anthropics/claude-agent-sdk-python#907.

https://claude.ai/code/session_01K21WBmdqs4dq6jHCDZxtR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K21WBmdqs4dq6jHCDZxtR2)_