### PR TITLE
fix: eliminate Enqueue/CloseContext race in transcriptMirrorBatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `transcriptMirrorBatcher`: eliminated a `send on closed channel` race between `Enqueue` and `CloseContext`. The flush-request channel send in `Enqueue` and the channel close in `CloseContext` now both occur while holding the batcher mutex, making concurrent calls safe. The race was benign in normal SDK use (message-reader exits before `CloseContext` runs) but would panic in tests or embedders that exercise both concurrently. ([#221](https://github.com/Flohs/claude-agent-sdk-go/issues/221))
+
 ### Added
 
 - `McpServerConnectionStatusRequesting` (`"requesting"`) constant for the `McpServerConnectionStatus` type, covering the CLI state while it is actively authenticating or connecting to a remote MCP server. Port of TypeScript SDK v0.2.108. ([#206](https://github.com/Flohs/claude-agent-sdk-go/issues/206))

--- a/transcript_mirror_batcher.go
+++ b/transcript_mirror_batcher.go
@@ -143,17 +143,16 @@ func (b *transcriptMirrorBatcher) Enqueue(filePath string, entries []SessionStor
 	b.pendingItems += len(entries)
 	b.pendingBytes += size
 	shouldFlush := b.eager || b.pendingItems > MirrorMaxPendingEntries || b.pendingBytes > MirrorMaxPendingBytes
-	b.mu.Unlock()
-
+	// Send the flush request while still holding the mutex so it can never
+	// race with CloseContext closing the channel. The send is non-blocking
+	// (default case) so the mutex is never held while waiting on I/O.
 	if shouldFlush {
-		// Fire-and-forget auto-flush. Send is non-blocking: if the worker
-		// is busy and the request buffer is full, the next explicit Flush /
-		// the next threshold-cross will pick up the still-pending items.
 		select {
 		case b.flushRequests <- flushRequest{}:
 		default:
 		}
 	}
+	b.mu.Unlock()
 }
 
 // Flush blocks until all currently-pending entries are flushed (or fail
@@ -208,11 +207,10 @@ func (b *transcriptMirrorBatcher) CloseContext(ctx context.Context) error {
 		return nil
 	}
 	b.closed = true
-	b.mu.Unlock()
-
-	// Signal the worker to drain any remaining items and exit. The worker
-	// reads from flushRequests until it is closed.
+	// Close the channel while holding the mutex so it cannot race with the
+	// non-blocking send in Enqueue (which also runs under the mutex).
 	close(b.flushRequests)
+	b.mu.Unlock()
 
 	// Wait for the worker goroutine in a side goroutine so the caller's
 	// ctx can interrupt the wait without leaking the wg-watcher.

--- a/transcript_mirror_batcher_test.go
+++ b/transcript_mirror_batcher_test.go
@@ -458,3 +458,43 @@ func TestTranscriptMirrorBatcher_EmptyFrameIsNoop(t *testing.T) {
 		t.Fatalf("expected no Append calls for empty frames, got %d", got)
 	}
 }
+
+// TestTranscriptMirrorBatcher_ConcurrentEnqueueCloseContext is a race-detector
+// regression test: Enqueue and CloseContext previously had a window where
+// Enqueue could send on a closed channel (panic), because the flush-request
+// send happened outside the mutex while CloseContext closed the channel also
+// outside the mutex.
+func TestTranscriptMirrorBatcher_ConcurrentEnqueueCloseContext(t *testing.T) {
+	projectsDir, pathFor := testProjectsDir(t)
+	sid := "dddddddd-dddd-dddd-dddd-dddddddddddd"
+	entries := []SessionStoreEntry{{"type": "user"}}
+
+	// Run many iterations so the race detector (go test -race) has a good
+	// chance of catching any surviving window.
+	for i := 0; i < 200; i++ {
+		store := &fakeStore{}
+		b := newTranscriptMirrorBatcher(store, projectsDir, nil, nil, true /* eager */)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+
+		// Goroutine 1: Enqueue a frame as soon as the start gate opens.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			b.Enqueue(pathFor(sid), entries)
+		}()
+
+		// Goroutine 2: CloseContext racing with the Enqueue above.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = b.CloseContext(context.Background())
+		}()
+
+		close(start) // release both goroutines simultaneously
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
Closes #221

## Summary

- Moves the flush-request channel send in `Enqueue` inside the mutex (non-blocking `select`/`default`).
- Moves `close(b.flushRequests)` in `CloseContext` inside the mutex.
- Adds `TestTranscriptMirrorBatcher_ConcurrentEnqueueCloseContext` race-detector regression test (200 eager-flush iterations).

## The race

`Enqueue` released the mutex before sending on `b.flushRequests`, while `CloseContext` closed that channel outside its own mutex scope. Between the two unlocks there was a window where Enqueue could attempt a send on an already-closed channel → **panic: send on closed channel**.

The race was dormant in normal SDK operation (the message-reader goroutine exits before `CloseContext` is called) but was reachable from tests or embedders that call both concurrently — and from the eager-flush code path where every `Enqueue` unconditionally triggers a send.

## Fix

Both the send (`Enqueue`) and the close (`CloseContext`) now run inside the same `b.mu` critical section. Since the send uses `select { case …: default: }` it never blocks while holding the lock.

https://claude.ai/code/session_01K21WBmdqs4dq6jHCDZxtR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K21WBmdqs4dq6jHCDZxtR2)_