### PR TITLE
test: cover per-line panic isolation in callStderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Tests
+
+- `TestHandleStderr_PanicInCallbackDoesNotAbortLoop`: regression test verifying that a panicking `Options.Stderr` callback does not abort the stderr-reader loop — all subsequent lines are still delivered. The behaviour was already correct (per-call `recover()` in `callStderr`), but there was no test to guard against a future regression. Port of Python SDK v0.2.82 PR #932. ([#223](https://github.com/Flohs/claude-agent-sdk-go/issues/223))
+
 ### Fixed
 
 - `extractCreatedAtFromHead` now scans all lines in the head buffer when looking for a `timestamp` field, instead of stopping at the first valid JSON entry that happens to lack one. `ListSessions` and `GetSessionInfo` previously returned `CreatedAt: nil` for sessions whose first JSONL record was a metadata/summary entry without a `timestamp` key. Port of Python SDK v0.1.74 PR #907. ([#220](https://github.com/Flohs/claude-agent-sdk-go/issues/220))

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -608,3 +608,37 @@ func TestBuildCommand_SessionMirrorFlag(t *testing.T) {
 		assertContainsFlag(t, cmd, "--session-mirror")
 	})
 }
+
+// TestHandleStderr_PanicInCallbackDoesNotAbortLoop is a regression test for
+// the stderr-callback panic-isolation guarantee (port of Python SDK v0.2.82
+// PR #932). A panicking Stderr callback must not abort the reading loop —
+// all subsequent stderr lines must still be delivered.
+func TestHandleStderr_PanicInCallbackDoesNotAbortLoop(t *testing.T) {
+	const totalLines = 5
+	const panicOnLine = 0 // panic on the very first delivery
+
+	var delivered []string
+
+	stderrFn := func(line string) {
+		delivered = append(delivered, line)
+		if len(delivered)-1 == panicOnLine {
+			panic("deliberate test panic")
+		}
+	}
+
+	// Call callStderr directly — it is the per-line panic-isolation wrapper
+	// that handleStderr invokes for every line. All lines must be delivered
+	// even when the callback panics on one of them.
+	transport := &SubprocessTransport{
+		options: &Options{Stderr: stderrFn},
+	}
+
+	for i := 0; i < totalLines; i++ {
+		transport.callStderr(strings.Repeat("x", i+1)) // unique, non-empty lines
+	}
+
+	if len(delivered) != totalLines {
+		t.Errorf("expected %d lines delivered, got %d — panic on line %d aborted the loop",
+			totalLines, len(delivered), panicOnLine)
+	}
+}


### PR DESCRIPTION
Closes #223

## Summary

- Adds `TestHandleStderr_PanicInCallbackDoesNotAbortLoop` to `subprocess_transport_test.go`.
- The test verifies that a panic in the user-supplied `Stderr` callback on line N does not prevent lines N+1…end from being delivered.

## Motivation

`SubprocessTransport.callStderr` already has per-line `recover()` logic, but there was no regression test for it. This covers the behavior and prevents future refactors from accidentally removing the panic isolation.

Port of Python SDK v0.1.74 PR anthropics/claude-agent-sdk-python#932.

https://claude.ai/code/session_01K21WBmdqs4dq6jHCDZxtR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K21WBmdqs4dq6jHCDZxtR2)_