### PR TITLE
feat: add ApiRetryMessage system message type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Added
 
+- `ApiRetryMessage` system message type emitted before each API retry attempt when the CLI encounters a transient error. Fields: `AttemptNumber`, `MaxAttempts`, `DelayMs`, `ErrorStatus *int`, `ErrorMessage`. Port of TypeScript SDK v0.2.77. ([#234](https://github.com/Flohs/claude-agent-sdk-go/issues/234))
 - `HookOutputKeyDecision`, `HookOutputKeyReason`, `HookOutputKeyUpdatedToolOutput`, and `HookOutputKeyUpdatedMCPToolOutput` exported string constants for the well-known `HookJSONOutput` map keys, replacing magic string literals. `HookJSONOutput`'s GoDoc is expanded with concrete usage examples for blocking tool calls and replacing tool output. Port of TypeScript SDK v0.2.121 / Python SDK v0.1.74. ([#224](https://github.com/Flohs/claude-agent-sdk-go/issues/224))
 - `McpServerConnectionStatusRequesting` (`"requesting"`) constant for the `McpServerConnectionStatus` type, covering the CLI state while it is actively authenticating or connecting to a remote MCP server. Port of TypeScript SDK v0.2.108. ([#206](https://github.com/Flohs/claude-agent-sdk-go/issues/206))
 - `PermissionPolicy map[string]string` field on `McpSSEServerConfig` and `McpHTTPServerConfig` for per-tool permission policies. Keys are tool names; values are `"allow"`, `"ask"`, or `"deny"`. Forwarded to the CLI via the `--mcp-config` JSON blob so the CLI applies the policy to session allow/deny rules without requiring a `CanUseTool` callback. Port of TypeScript SDK v0.2.111. ([#208](https://github.com/Flohs/claude-agent-sdk-go/issues/208))

--- a/message_parser.go
+++ b/message_parser.go
@@ -200,6 +200,21 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 			TaskDescription: stringField(data, "task_description"),
 		}, nil
 
+	case "api_retry":
+		msg := &ApiRetryMessage{
+			SystemMessage: base,
+			AttemptNumber: intField(data, "attempt_number"),
+			MaxAttempts:   intField(data, "max_attempts"),
+			DelayMs:       intField(data, "delay_ms"),
+			ErrorMessage:  stringField(data, "error_message"),
+		}
+		if v, ok := data["error_status"]; ok {
+			if status := intFromAny(v); status != 0 {
+				msg.ErrorStatus = &status
+			}
+		}
+		return msg, nil
+
 	default:
 		return &base, nil
 	}

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -930,6 +930,82 @@ func TestParseMessage_TaskProgress_SubagentTypeAndDescription(t *testing.T) {
 	}
 }
 
+func TestParseMessage_ApiRetry(t *testing.T) {
+	status := 429
+	data := map[string]any{
+		"type":           "system",
+		"subtype":        "api_retry",
+		"attempt_number": float64(2),
+		"max_attempts":   float64(5),
+		"delay_ms":       float64(1000),
+		"error_status":   float64(429),
+		"error_message":  "Too Many Requests",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := msg.(*ApiRetryMessage)
+	if !ok {
+		t.Fatalf("expected *ApiRetryMessage, got %T", msg)
+	}
+	if m.AttemptNumber != 2 {
+		t.Errorf("AttemptNumber: got %d, want 2", m.AttemptNumber)
+	}
+	if m.MaxAttempts != 5 {
+		t.Errorf("MaxAttempts: got %d, want 5", m.MaxAttempts)
+	}
+	if m.DelayMs != 1000 {
+		t.Errorf("DelayMs: got %d, want 1000", m.DelayMs)
+	}
+	if m.ErrorStatus == nil || *m.ErrorStatus != status {
+		t.Errorf("ErrorStatus: got %v, want %d", m.ErrorStatus, status)
+	}
+	if m.ErrorMessage != "Too Many Requests" {
+		t.Errorf("ErrorMessage: got %q, want 'Too Many Requests'", m.ErrorMessage)
+	}
+	if m.Subtype != "api_retry" {
+		t.Errorf("Subtype: got %q, want 'api_retry'", m.Subtype)
+	}
+}
+
+func TestParseMessage_ApiRetry_NoErrorStatus(t *testing.T) {
+	data := map[string]any{
+		"type":           "system",
+		"subtype":        "api_retry",
+		"attempt_number": float64(1),
+		"max_attempts":   float64(3),
+		"delay_ms":       float64(500),
+		"error_message":  "connection reset by peer",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := msg.(*ApiRetryMessage)
+	if !ok {
+		t.Fatalf("expected *ApiRetryMessage, got %T", msg)
+	}
+	if m.ErrorStatus != nil {
+		t.Errorf("ErrorStatus: got %v, want nil", m.ErrorStatus)
+	}
+	if m.AttemptNumber != 1 {
+		t.Errorf("AttemptNumber: got %d, want 1", m.AttemptNumber)
+	}
+	if m.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts: got %d, want 3", m.MaxAttempts)
+	}
+	if m.DelayMs != 500 {
+		t.Errorf("DelayMs: got %d, want 500", m.DelayMs)
+	}
+	if m.ErrorMessage != "connection reset by peer" {
+		t.Errorf("ErrorMessage: got %q, want 'connection reset by peer'", m.ErrorMessage)
+	}
+	if m.Subtype != "api_retry" {
+		t.Errorf("Subtype: got %q, want 'api_retry'", m.Subtype)
+	}
+}
+
 func TestParseMessage_TaskNotification_SubagentTypeAndDescription(t *testing.T) {
 	data := map[string]any{
 		"type":             "system",

--- a/types.go
+++ b/types.go
@@ -354,6 +354,23 @@ type MirrorErrorMessage struct {
 	SessionID string      `json:"session_id,omitempty"`
 }
 
+// ApiRetryMessage is emitted before each API retry attempt when the CLI
+// encounters a transient API error. Port of TypeScript SDK v0.2.77.
+type ApiRetryMessage struct {
+	SystemMessage
+	// AttemptNumber is the current attempt (1-based; 1 = first retry after the initial failure).
+	AttemptNumber int `json:"attempt_number"`
+	// MaxAttempts is the maximum number of attempts, including the initial one.
+	MaxAttempts int `json:"max_attempts"`
+	// DelayMs is the delay in milliseconds before this attempt.
+	DelayMs int `json:"delay_ms"`
+	// ErrorStatus is the HTTP status code that triggered the retry (e.g. 429, 529).
+	// Nil when the error was not an HTTP error.
+	ErrorStatus *int `json:"error_status,omitempty"`
+	// ErrorMessage is a human-readable description of the error that triggered the retry.
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
 // HookDecision represents a hook's permission decision value.
 type HookDecision string
 


### PR DESCRIPTION
## Summary

- Adds `ApiRetryMessage` struct in `types.go` — a new system message type emitted before each API retry attempt when the CLI encounters a transient error
- Adds `case "api_retry":` in `parseSystemMessage` (`message_parser.go`) using the same optional-int pattern as `ResultMessage.APIErrorStatus`
- Adds two tests in `message_parser_test.go`: one with `ErrorStatus` set (429), one without (nil case)
- Updates `CHANGELOG.md` under `[Unreleased] → Added`

Closes #234. Port of TypeScript SDK v0.2.77.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests + 2 new tests: `TestParseMessage_ApiRetry`, `TestParseMessage_ApiRetry_NoErrorStatus`)

https://claude.ai/code/session_01KFrGosxVnLsKdfiEF3F9Cj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFrGosxVnLsKdfiEF3F9Cj)_