### PR TITLE
feat: register subprocess cleanup handler on SIGINT/SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Added
 
+- CLI subprocesses are now registered in a global process registry and automatically terminated on `SIGINT`/`SIGTERM`, preventing orphaned `claude` processes when the parent Go program exits without calling `Close()`. Port of Python SDK v0.1.74 PR #916. ([#238](https://github.com/Flohs/claude-agent-sdk-go/issues/238))
 - `ApiRetryMessage` system message type emitted before each API retry attempt when the CLI encounters a transient error. Fields: `AttemptNumber`, `MaxAttempts`, `DelayMs`, `ErrorStatus *int`, `ErrorMessage`. Port of TypeScript SDK v0.2.77. ([#234](https://github.com/Flohs/claude-agent-sdk-go/issues/234))
 - `HookOutputKeyDecision`, `HookOutputKeyReason`, `HookOutputKeyUpdatedToolOutput`, and `HookOutputKeyUpdatedMCPToolOutput` exported string constants for the well-known `HookJSONOutput` map keys, replacing magic string literals. `HookJSONOutput`'s GoDoc is expanded with concrete usage examples for blocking tool calls and replacing tool output. Port of TypeScript SDK v0.2.121 / Python SDK v0.1.74. ([#224](https://github.com/Flohs/claude-agent-sdk-go/issues/224))
 - `McpServerConnectionStatusRequesting` (`"requesting"`) constant for the `McpServerConnectionStatus` type, covering the CLI state while it is actively authenticating or connecting to a remote MCP server. Port of TypeScript SDK v0.2.108. ([#206](https://github.com/Flohs/claude-agent-sdk-go/issues/206))

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -8,19 +8,79 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
+// activeChildren tracks all live CLI subprocess Commands so they can be
+// terminated when the parent Go process exits unexpectedly.
+// This mirrors Python SDK v0.1.74 PR #916 / TypeScript SDK parent-exit cleanup.
+var (
+	activeChildrenMu sync.Mutex
+	activeChildren   []*exec.Cmd
+)
+
+func registerChild(cmd *exec.Cmd) {
+	activeChildrenMu.Lock()
+	activeChildren = append(activeChildren, cmd)
+	activeChildrenMu.Unlock()
+}
+
+func unregisterChild(cmd *exec.Cmd) {
+	activeChildrenMu.Lock()
+	for i, c := range activeChildren {
+		if c == cmd {
+			activeChildren = append(activeChildren[:i], activeChildren[i+1:]...)
+			break
+		}
+	}
+	activeChildrenMu.Unlock()
+}
+
+func killActiveChildren() {
+	activeChildrenMu.Lock()
+	cmds := make([]*exec.Cmd, len(activeChildren))
+	copy(cmds, activeChildren)
+	activeChildren = activeChildren[:0]
+	activeChildrenMu.Unlock()
+	for _, cmd := range cmds {
+		if cmd.Process != nil {
+			if runtime.GOOS == "windows" {
+				_ = cmd.Process.Kill()
+			} else {
+				_ = cmd.Process.Signal(os.Interrupt)
+			}
+		}
+	}
+}
+
+func init() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		killActiveChildren()
+		// Re-raise the signal with the default handler so the process exits
+		// with the correct status code.
+		signal.Reset(os.Interrupt, syscall.SIGTERM)
+		proc, _ := os.FindProcess(os.Getpid())
+		if proc != nil {
+			_ = proc.Signal(syscall.SIGTERM)
+		}
+	}()
+}
+
 const (
-	defaultMaxBufferSize       = 1024 * 1024 // 1MB
-	minimumClaudeCodeVersion   = "2.1.90"
-	sdkVersion                 = "2.0.0"
+	defaultMaxBufferSize     = 1024 * 1024 // 1MB
+	minimumClaudeCodeVersion = "2.1.90"
+	sdkVersion               = "2.0.0"
 )
 
 // SubprocessTransport implements Transport using the Claude Code CLI subprocess.
@@ -146,6 +206,7 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 	}
 
 	t.cmd = cmd
+	registerChild(cmd)
 	t.ready = true
 
 	// Handle stderr in background
@@ -234,7 +295,8 @@ func (t *SubprocessTransport) ReadMessages(ctx context.Context) <-chan map[strin
 
 		// Wait for process to finish and check exit code
 		if t.cmd != nil {
-			if err := t.cmd.Wait(); err != nil {
+			cmd := t.cmd
+			if err := cmd.Wait(); err != nil {
 				if exitErr, ok := err.(*exec.ExitError); ok {
 					code := exitErr.ExitCode()
 					select {
@@ -246,6 +308,7 @@ func (t *SubprocessTransport) ReadMessages(ctx context.Context) <-chan map[strin
 					}
 				}
 			}
+			unregisterChild(cmd)
 		}
 	}()
 
@@ -265,22 +328,24 @@ func (t *SubprocessTransport) Close() error {
 	}
 
 	if t.cmd != nil && t.cmd.Process != nil {
+		cmd := t.cmd
 		done := make(chan error, 1)
-		go func() { done <- t.cmd.Wait() }()
+		go func() { done <- cmd.Wait() }()
 		// Wait for process to exit naturally after stdin close
 		select {
 		case <-done:
 			// Process exited cleanly — no signal needed
 		case <-time.After(5 * time.Second):
 			// Grace period expired — escalate to SIGINT
-			_ = t.cmd.Process.Signal(os.Interrupt)
+			_ = cmd.Process.Signal(os.Interrupt)
 			select {
 			case <-done:
 			case <-time.After(5 * time.Second):
-				_ = t.cmd.Process.Kill()
+				_ = cmd.Process.Kill()
 				<-done
 			}
 		}
+		unregisterChild(cmd)
 	}
 
 	t.cmd = nil


### PR DESCRIPTION
## Summary

- Adds a global `activeChildren []*exec.Cmd` registry (protected by `sync.Mutex`) in `subprocess_transport.go` to track all live CLI subprocess handles.
- Installs a `SIGINT`/`SIGTERM` handler in `init()` that terminates all registered children then re-raises the signal so the process exits with the correct status code, preventing orphaned `claude` processes.
- Calls `registerChild(cmd)` immediately after `cmd.Start()` succeeds in `Connect()`, and `unregisterChild(cmd)` after `cmd.Wait()` returns in both `Close()` and the `ReadMessages` goroutine.
- On Windows, `Process.Kill()` is used instead of `Signal(os.Interrupt)` since `os.Interrupt` is not supported on that platform.

Port of Python SDK v0.1.74 PR #916.

Closes #238

## Test plan

- [x] `go build ./...` passes with no errors
- [x] `go test ./...` passes — all existing tests green
- [ ] Manual: run an example that calls `os.Exit()` mid-session and confirm no orphaned `claude` processes remain in `ps aux`
- [ ] Manual: send SIGINT/SIGTERM to a running example and confirm child processes are cleaned up

https://claude.ai/code/session_01KFrGosxVnLsKdfiEF3F9Cj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFrGosxVnLsKdfiEF3F9Cj)_