### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-26
+
 ### Documentation
 
 - `HookMatcher`: added a **"Dispatch order"** GoDoc section clarifying that all matchers registered for a given event are dispatched concurrently (in parallel), not sequentially. Hook latency is bounded by the slowest single hook, and registration order does not determine execution order. Ordering-dependent designs (e.g. rate-limiters gating subsequent hooks) are not supported. Port of Python SDK v0.2.82 PR #956. ([#222](https://github.com/Flohs/claude-agent-sdk-go/issues/222))


### PR DESCRIPTION
Promotes `## [Unreleased]` → `## [2.1.0] - 2026-05-26` in CHANGELOG.md.

## What's in v2.1.0

**New features**
- `Startup()` / `WarmQuery` — pre-warm CLI subprocess for ~20× faster first query latency (#239)
- `ElicitationCompleteMessage` + `HookEventElicitation` / `ElicitationHookInput` — MCP elicitation support (#237)
- `MemoryRecallMessage` + `ServerCapabilities.MemoryPaths` — memory file tracking (#235)
- `ApiRetryMessage` — typed system message on API retry (#234)
- `ExitPlanModeToolInput` — typed struct for ExitPlanMode tool input (#236)
- `PostToolUseHookOutput` — typed struct for PostToolUse hook return values (#230)
- `HookOutputKey*` constants — exported keys for `HookJSONOutput` map (#224)
- `PermissionPolicy` on MCP server configs (#208)
- `Client.AppendMessage` — inject context without triggering a response turn (#209)
- `Options.Debug` / `Options.DebugFile` (#207)
- `ServerCapabilities` struct from init result (#210)
- `EffortLevel` type alias (#216)
- `McpServerConnectionStatusRequesting` constant (#206)

**Bug fixes**
- `extractCreatedAtFromHead` scans all head lines for timestamp (#220)
- Batcher race: `send on closed channel` panic eliminated (#221)
- Subprocess cleanup on SIGINT/SIGTERM (#238)

https://claude.ai/code/session_01Kgw8bJ5QZjJXyKR4cf7hVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgw8bJ5QZjJXyKR4cf7hVs)_