### PR TITLE
fix: repair missing closing braces from rebase conflict resolution

### DIFF
--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -779,6 +779,7 @@ func TestExitPlanModeToolInput_Roundtrip(t *testing.T) {
 	b2, _ := json.Marshal(empty)
 	if string(b2) != "{}" {
 		t.Errorf("empty struct should marshal to {}, got %s", b2)
+	}
 }
 
 func TestParseHookInput_Elicitation(t *testing.T) {

--- a/message_parser.go
+++ b/message_parser.go
@@ -228,6 +228,8 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 		return &MemoryRecallMessage{
 			SystemMessage: base,
 			Paths:         paths,
+		}, nil
+
 	case "elicitation_complete":
 		var result map[string]any
 		if r, ok := data["result"].(map[string]any); ok {

--- a/types.go
+++ b/types.go
@@ -387,6 +387,8 @@ type MemoryRecallMessage struct {
 	SystemMessage
 	// Paths is the list of memory file paths that were loaded.
 	Paths []string `json:"paths,omitempty"`
+}
+
 // ElicitationCompleteMessage is emitted when an MCP server's elicitation
 // request completes. MCP elicitation allows MCP servers to request user input
 // programmatically (MCP protocol 2025-11-05). Port of TypeScript SDK v0.2.76.


### PR DESCRIPTION
Fixes three syntax errors introduced when an automated conflict resolver dropped closing braces/return-values while concatenating both sides of a merge conflict.

**Files fixed:**
- `message_parser.go`: `memory_recall` case was missing `}, nil` before `elicitation_complete` case
- `types.go`: `MemoryRecallMessage` struct was missing its closing `}`
- `hook_input_parser_test.go`: `TestExitPlanModeToolInput_Roundtrip` was missing `}` on inner if-block

`go build ./...`, `go vet ./...`, and `go test ./...` all pass locally.

https://claude.ai/code/session_01Kgw8bJ5QZjJXyKR4cf7hVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgw8bJ5QZjJXyKR4cf7hVs)_