### PR TITLE
ci: add release workflow triggered on v* tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          # Extract the section between ## [VERSION] and the next ## [
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          # Write to file to handle multi-line content
+          echo "$NOTES" > /tmp/release_notes.md
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/release_notes.md


### PR DESCRIPTION
Adds `.github/workflows/release.yml` that fires on any `v*` tag push.

The workflow:
1. Extracts the matching version section from `CHANGELOG.md` using `awk`
2. Creates a GitHub release via `gh release create` with those notes

**For the existing v2.1.0 tag:** once this PR is merged, delete and re-push the tag to trigger the workflow:
```bash
git push origin :v2.1.0   # delete remote tag
git push origin v2.1.0    # re-push to fire the workflow
```

https://claude.ai/code/session_01Kgw8bJ5QZjJXyKR4cf7hVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgw8bJ5QZjJXyKR4cf7hVs)_