### PR TITLE
fix: repair remaining syntax errors from v2.1.0 rebase conflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `message_parser.go`: `MemoryRecallMessage` switch-case branch was missing `}, nil` before `case "elicitation_complete":`, leaving the struct literal open and causing a parse error. Residual from the v2.1.0 rebase conflict resolution.
+- `types.go`: `MemoryRecallMessage` struct definition was missing its closing `}`, causing a parse error. Residual from the v2.1.0 rebase conflict resolution.
+- `hook_input_parser_test.go`: `TestExitPlanModeToolInput_Roundtrip` was missing the closing `}` on the inner if-block, causing a parse error. Residual from the v2.1.0 rebase conflict resolution.
+
 ## [2.1.0] - 2026-05-26
 
 ### Documentation

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -779,6 +779,7 @@ func TestExitPlanModeToolInput_Roundtrip(t *testing.T) {
 	b2, _ := json.Marshal(empty)
 	if string(b2) != "{}" {
 		t.Errorf("empty struct should marshal to {}, got %s", b2)
+	}
 }
 
 func TestParseHookInput_Elicitation(t *testing.T) {

--- a/message_parser.go
+++ b/message_parser.go
@@ -228,6 +228,8 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 		return &MemoryRecallMessage{
 			SystemMessage: base,
 			Paths:         paths,
+		}, nil
+
 	case "elicitation_complete":
 		var result map[string]any
 		if r, ok := data["result"].(map[string]any); ok {

--- a/types.go
+++ b/types.go
@@ -387,6 +387,8 @@ type MemoryRecallMessage struct {
 	SystemMessage
 	// Paths is the list of memory file paths that were loaded.
 	Paths []string `json:"paths,omitempty"`
+}
+
 // ElicitationCompleteMessage is emitted when an MCP server's elicitation
 // request completes. MCP elicitation allows MCP servers to request user input
 // programmatically (MCP protocol 2025-11-05). Port of TypeScript SDK v0.2.76.


### PR DESCRIPTION
## Summary

Three files still had truncated conflict resolutions after #247, leaving the build broken on `main`:

- `message_parser.go`: `MemoryRecallMessage` switch-case branch missing `}, nil` before `case "elicitation_complete":` — struct literal was never closed
- `types.go`: `MemoryRecallMessage` struct definition missing closing `}` — next type declaration was inside the struct
- `hook_input_parser_test.go`: `TestExitPlanModeToolInput_Roundtrip` missing closing `}` on the inner if-block — function was never closed

## Test plan

- [ ] `go build ./...` succeeds
- [ ] `go test ./...` passes (all tests green)

https://claude.ai/code/session_01Wedj1LEcb8bjjwwYKEaqXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wedj1LEcb8bjjwwYKEaqXL)_