### PR TITLE
feat: add MessageDisplay hook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `HookEventMessageDisplay` (`"MessageDisplay"`) hook event constant, `MessageDisplayHookInput` typed struct (fields: `TurnID`, `MessageID`, `Index`, `Final`, `Delta`), and `MessageDisplayHookOutput` typed output struct with `DisplayContent *string` and `ToHookJSONOutput()` helper. The `MessageDisplay` hook fires during assistant message streaming; returning a non-nil `DisplayContent` replaces the text shown to the user. Display-only: the stored message and what the model sees are untouched. Port of TypeScript SDK v0.3.152. ([#249](https://github.com/Flohs/claude-agent-sdk-go/issues/249))
+
 ### Fixed
 
 - `message_parser.go`: `MemoryRecallMessage` switch-case branch was missing `}, nil` before `case "elicitation_complete":`, leaving the struct literal open and causing a parse error. Residual from the v2.1.0 rebase conflict resolution.

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -127,6 +127,16 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			RequestedSchema: schema,
 		}, nil
 
+	case HookEventMessageDisplay:
+		return &MessageDisplayHookInput{
+			BaseHookInput: base,
+			TurnID:        stringField(input, "turn_id"),
+			MessageID:     stringField(input, "message_id"),
+			Index:         intField(input, "index"),
+			Final:         boolField(input, "final"),
+			Delta:         stringField(input, "delta"),
+		}, nil
+
 	default:
 		// Forward-compatible: return nil for unrecognized events.
 		return nil, nil

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -23,6 +23,7 @@ var (
 	_ TypedHookInput = (*TaskCompletedHookInput)(nil)
 	_ TypedHookInput = (*ConfigChangeHookInput)(nil)
 	_ TypedHookInput = (*ElicitationHookInput)(nil)
+	_ TypedHookInput = (*MessageDisplayHookInput)(nil)
 )
 
 // base returns a HookInput with common fields pre-filled.
@@ -846,5 +847,61 @@ func TestParseMessage_ElicitationComplete(t *testing.T) {
 	}
 	if m.Subtype != "elicitation_complete" {
 		t.Errorf("Subtype: got %q, want 'elicitation_complete'", m.Subtype)
+	}
+}
+
+func TestParseHookInput_MessageDisplay(t *testing.T) {
+	input := HookInput{
+		"session_id":       "sess-md",
+		"transcript_path":  "/path/session.jsonl",
+		"cwd":              "/home/user",
+		"permission_mode":  "default",
+		"hook_event_name":  "MessageDisplay",
+		"turn_id":          "turn-001",
+		"message_id":       "msg-xyz",
+		"index":            float64(3),
+		"final":            true,
+		"delta":            "Hello, world!\n",
+	}
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(*MessageDisplayHookInput)
+	if !ok {
+		t.Fatalf("expected *MessageDisplayHookInput, got %T", result)
+	}
+	if m.SessionID != "sess-md" {
+		t.Errorf("SessionID: got %q, want 'sess-md'", m.SessionID)
+	}
+	if m.TurnID != "turn-001" {
+		t.Errorf("TurnID: got %q, want 'turn-001'", m.TurnID)
+	}
+	if m.MessageID != "msg-xyz" {
+		t.Errorf("MessageID: got %q, want 'msg-xyz'", m.MessageID)
+	}
+	if m.Index != 3 {
+		t.Errorf("Index: got %d, want 3", m.Index)
+	}
+	if !m.Final {
+		t.Error("Final: expected true")
+	}
+	if m.Delta != "Hello, world!\n" {
+		t.Errorf("Delta: got %q, want 'Hello, world!\\n'", m.Delta)
+	}
+}
+
+func TestMessageDisplayHookOutput_ToHookJSONOutput(t *testing.T) {
+	content := "transformed text"
+	out := MessageDisplayHookOutput{DisplayContent: &content}
+	j := out.ToHookJSONOutput()
+	if j["displayContent"] != content {
+		t.Errorf("displayContent: got %v, want %q", j["displayContent"], content)
+	}
+
+	empty := MessageDisplayHookOutput{}
+	j2 := empty.ToHookJSONOutput()
+	if _, ok := j2["displayContent"]; ok {
+		t.Error("displayContent should be absent when nil")
 	}
 }

--- a/hooks.go
+++ b/hooks.go
@@ -30,6 +30,12 @@ const (
 	// return a response map to provide the input programmatically, skipping
 	// any interactive prompt. Port of TypeScript SDK v0.2.76.
 	HookEventElicitation HookEvent = "Elicitation"
+	// HookEventMessageDisplay fires during assistant message streaming, allowing
+	// hooks to transform or hide the displayed text. The Delta field contains
+	// newly completed lines since the prior flush. Display-only: the stored
+	// message and what the model sees are untouched.
+	// Port of TypeScript SDK v0.3.152.
+	HookEventMessageDisplay HookEvent = "MessageDisplay"
 )
 
 // HookInput represents the input data for a hook callback.
@@ -212,6 +218,44 @@ type ElicitationHookInput struct {
 }
 
 func (*ElicitationHookInput) hookInputMarker() {}
+
+// MessageDisplayHookInput is the typed input for MessageDisplay hook events.
+// Fires during assistant message streaming. Delta contains newly completed
+// lines since the prior flush. Display-only: the stored message and what the
+// model sees are untouched. Port of TypeScript SDK v0.3.152.
+type MessageDisplayHookInput struct {
+	BaseHookInput
+	// TurnID identifies the current conversation turn.
+	TurnID string `json:"turn_id"`
+	// MessageID identifies the specific message being displayed.
+	MessageID string `json:"message_id"`
+	// Index is the position of this delta within the message stream.
+	Index int `json:"index"`
+	// Final indicates this is the last delta for the message.
+	Final bool `json:"final"`
+	// Delta contains the newly completed lines since the prior flush.
+	Delta string `json:"delta"`
+}
+
+func (*MessageDisplayHookInput) hookInputMarker() {}
+
+// MessageDisplayHookOutput is the typed output for [HookEventMessageDisplay]
+// callbacks. Port of TypeScript SDK v0.3.152.
+type MessageDisplayHookOutput struct {
+	// DisplayContent, when non-nil, replaces the text shown to the user.
+	// Display-only: does not affect the stored message or what the model sees.
+	DisplayContent *string
+}
+
+// ToHookJSONOutput converts the typed struct to a [HookJSONOutput] map suitable
+// for returning from a [HookCallback]. Fields with a nil value are omitted.
+func (o MessageDisplayHookOutput) ToHookJSONOutput() HookJSONOutput {
+	out := HookJSONOutput{}
+	if o.DisplayContent != nil {
+		out["displayContent"] = *o.DisplayContent
+	}
+	return out
+}
 
 // HookContext provides context for hook callbacks.
 type HookContext struct {


### PR DESCRIPTION
## Summary

Port of TypeScript SDK v0.3.152. Adds the `MessageDisplay` hook event that fires during assistant message streaming.

- `HookEventMessageDisplay` (`"MessageDisplay"`) constant
- `MessageDisplayHookInput` struct with `TurnID`, `MessageID`, `Index`, `Final`, `Delta` fields
- `MessageDisplayHookOutput` typed output struct with `DisplayContent *string` and `ToHookJSONOutput()` helper
- Parser case in `ParseHookInput`
- Compile-time interface check + round-trip tests

A non-nil `DisplayContent` replaces the text shown to the user. Display-only: does not affect the stored message or what the model sees.

Closes #249

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes — `TestParseHookInput_MessageDisplay` and `TestMessageDisplayHookOutput_ToHookJSONOutput`

https://claude.ai/code/session_01Wedj1LEcb8bjjwwYKEaqXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wedj1LEcb8bjjwwYKEaqXL)_