### PR TITLE
feat: add SessionStart hook input/output with reloadSkills and sessionTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `HookEventMessageDisplay` (`"MessageDisplay"`) hook event constant, `MessageDisplayHookInput` typed struct (fields: `TurnID`, `MessageID`, `Index`, `Final`, `Delta`), and `MessageDisplayHookOutput` typed output struct with `DisplayContent *string` and `ToHookJSONOutput()` helper. The `MessageDisplay` hook fires during assistant message streaming; returning a non-nil `DisplayContent` replaces the text shown to the user. Display-only: the stored message and what the model sees are untouched. Port of TypeScript SDK v0.3.152. ([#249](https://github.com/Flohs/claude-agent-sdk-go/issues/249))
+- `HookEventSessionStart` (`"SessionStart"`) hook event constant, `SessionStartHookInput` typed struct, and `SessionStartHookOutput` typed output with `ReloadSkills bool`, `SessionTitle string`, and `ToHookJSONOutput()`. Returning `ReloadSkills: true` triggers a skill re-scan; `SessionTitle` sets the session title at initialization via `hookSpecificOutput.sessionTitle`. Port of TypeScript SDK v0.3.152. ([#250](https://github.com/Flohs/claude-agent-sdk-go/issues/250))
 
 ### Fixed
 

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -137,6 +137,11 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			Delta:         stringField(input, "delta"),
 		}, nil
 
+	case HookEventSessionStart:
+		return &SessionStartHookInput{
+			BaseHookInput: base,
+		}, nil
+
 	default:
 		// Forward-compatible: return nil for unrecognized events.
 		return nil, nil

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -24,6 +24,7 @@ var (
 	_ TypedHookInput = (*ConfigChangeHookInput)(nil)
 	_ TypedHookInput = (*ElicitationHookInput)(nil)
 	_ TypedHookInput = (*MessageDisplayHookInput)(nil)
+	_ TypedHookInput = (*SessionStartHookInput)(nil)
 )
 
 // base returns a HookInput with common fields pre-filled.
@@ -817,6 +818,47 @@ func TestParseHookInput_Elicitation(t *testing.T) {
 	}
 	if m.RequestedSchema == nil {
 		t.Error("RequestedSchema should not be nil")
+	}
+}
+
+func TestParseHookInput_SessionStart(t *testing.T) {
+	input := base("SessionStart")
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(*SessionStartHookInput)
+	if !ok {
+		t.Fatalf("expected *SessionStartHookInput, got %T", result)
+	}
+	if m.SessionID != "sess-1" {
+		t.Errorf("SessionID: got %q, want 'sess-1'", m.SessionID)
+	}
+}
+
+func TestSessionStartHookOutput_ToHookJSONOutput(t *testing.T) {
+	out := SessionStartHookOutput{ReloadSkills: true, SessionTitle: "My Session"}
+	j := out.ToHookJSONOutput()
+	if j["reloadSkills"] != true {
+		t.Errorf("reloadSkills: got %v, want true", j["reloadSkills"])
+	}
+	nested, ok := j["hookSpecificOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("hookSpecificOutput should be map, got %T", j["hookSpecificOutput"])
+	}
+	if nested["sessionTitle"] != "My Session" {
+		t.Errorf("sessionTitle: got %v, want 'My Session'", nested["sessionTitle"])
+	}
+}
+
+func TestSessionStartHookOutput_Empty_ToHookJSONOutput(t *testing.T) {
+	out := SessionStartHookOutput{}
+	j := out.ToHookJSONOutput()
+	if _, ok := j["reloadSkills"]; ok {
+		t.Error("reloadSkills should be absent when false")
+	}
+	if _, ok := j["hookSpecificOutput"]; ok {
+		t.Error("hookSpecificOutput should be absent when SessionTitle is empty")
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -36,6 +36,9 @@ const (
 	// message and what the model sees are untouched.
 	// Port of TypeScript SDK v0.3.152.
 	HookEventMessageDisplay HookEvent = "MessageDisplay"
+	// HookEventSessionStart fires at the beginning of a session, before the first
+	// user turn. Port of TypeScript SDK v0.3.152.
+	HookEventSessionStart HookEvent = "SessionStart"
 )
 
 // HookInput represents the input data for a hook callback.
@@ -253,6 +256,36 @@ func (o MessageDisplayHookOutput) ToHookJSONOutput() HookJSONOutput {
 	out := HookJSONOutput{}
 	if o.DisplayContent != nil {
 		out["displayContent"] = *o.DisplayContent
+	}
+	return out
+}
+
+// SessionStartHookInput is the typed input for SessionStart hook events.
+// Fires at session initialization before the first user turn.
+// Port of TypeScript SDK v0.3.152.
+type SessionStartHookInput struct {
+	BaseHookInput
+}
+
+func (*SessionStartHookInput) hookInputMarker() {}
+
+// SessionStartHookOutput is the typed output for [HookEventSessionStart]
+// callbacks. Port of TypeScript SDK v0.3.152.
+type SessionStartHookOutput struct {
+	// ReloadSkills, when true, triggers a skill re-scan during session start.
+	ReloadSkills bool
+	// SessionTitle, when non-empty, sets the session title during initialization.
+	SessionTitle string
+}
+
+// ToHookJSONOutput converts the typed struct to a [HookJSONOutput] map.
+func (o SessionStartHookOutput) ToHookJSONOutput() HookJSONOutput {
+	out := HookJSONOutput{}
+	if o.ReloadSkills {
+		out["reloadSkills"] = true
+	}
+	if o.SessionTitle != "" {
+		out["hookSpecificOutput"] = map[string]any{"sessionTitle": o.SessionTitle}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Port of TypeScript SDK v0.3.152. Adds the `SessionStart` hook event constant, its typed input struct, and a typed output struct.

- `HookEventSessionStart` (`"SessionStart"`) constant
- `SessionStartHookInput` struct (embeds `BaseHookInput`)
- `SessionStartHookOutput` typed output struct with `ReloadSkills bool` and `SessionTitle string`, plus `ToHookJSONOutput()` helper
- Parser case in `ParseHookInput`
- Round-trip tests

`ReloadSkills: true` triggers a skill re-scan during session start. A non-empty `SessionTitle` sets the session title during initialization.

Closes #250

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjrCG4LjWhUjVNdDinStKo)_