### PR TITLE
docs: clarify Options.Env merge behavior and CLAUDE_AGENT_SDK_VERSION guarantee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `HookEventMessageDisplay` (`"MessageDisplay"`) hook event constant, `MessageDisplayHookInput` typed struct (fields: `TurnID`, `MessageID`, `Index`, `Final`, `Delta`), and `MessageDisplayHookOutput` typed output struct with `DisplayContent *string` and `ToHookJSONOutput()` helper. The `MessageDisplay` hook fires during assistant message streaming; returning a non-nil `DisplayContent` replaces the text shown to the user. Display-only: the stored message and what the model sees are untouched. Port of TypeScript SDK v0.3.152. ([#249](https://github.com/Flohs/claude-agent-sdk-go/issues/249))
 - `HookEventSessionStart` (`"SessionStart"`) hook event constant, `SessionStartHookInput` typed struct, and `SessionStartHookOutput` typed output with `ReloadSkills bool`, `SessionTitle string`, and `ToHookJSONOutput()`. Returning `ReloadSkills: true` triggers a skill re-scan; `SessionTitle` sets the session title at initialization via `hookSpecificOutput.sessionTitle`. Port of TypeScript SDK v0.3.152. ([#250](https://github.com/Flohs/claude-agent-sdk-go/issues/250))
 
+### Documentation
+
+- `Options.Env`: expanded GoDoc to describe the four-layer merge order (SDK defaults → inherited `os.Environ()` → user-provided `Env` entries → SDK-controlled vars), clarify that `CLAUDE_AGENT_SDK_VERSION` is always set by the SDK and cannot be overridden via `Env`, and note that `CLAUDECODE` is filtered from the inherited env. Note that unlike the TypeScript SDK (where `options.env` replaces the subprocess environment), the Go SDK merges `Env` on top of the inherited environment. Port of TypeScript SDK v0.3.149. ([#251](https://github.com/Flohs/claude-agent-sdk-go/issues/251))
+
 ### Fixed
 
 - `message_parser.go`: `MemoryRecallMessage` switch-case branch was missing `}, nil` before `case "elicitation_complete":`, leaving the struct literal open and causing a parse error. Residual from the v2.1.0 rebase conflict resolution.

--- a/options.go
+++ b/options.go
@@ -239,7 +239,16 @@ type Options struct {
 	ManagedSettings string
 	// AddDirs adds additional directories.
 	AddDirs []string
-	// Env sets additional environment variables for the CLI process.
+	// Env sets additional environment variables for the CLI subprocess. Entries
+	// are merged with the inherited process environment using a four-layer order:
+	//   1. SDK defaults (e.g. CLAUDE_CODE_ENTRYPOINT=sdk-go)
+	//   2. Inherited os.Environ() (CLAUDECODE is stripped to prevent nested-SDK interference)
+	//   3. Entries from Env (these override step 2)
+	//   4. SDK-controlled vars appended last (CLAUDE_AGENT_SDK_VERSION is always set
+	//      by the SDK and cannot be overridden via Env)
+	//
+	// Note: unlike the TypeScript SDK (where options.env replaces the subprocess
+	// environment), the Go SDK merges Env on top of the inherited environment.
 	Env map[string]string
 	// Debug enables verbose debug logging from the CLI subprocess.
 	Debug bool


### PR DESCRIPTION
## Summary

Analogue of TypeScript SDK v0.3.149. Expands the GoDoc for `Options.Env` to describe the four-layer merge order, clarify that `CLAUDE_AGENT_SDK_VERSION` is always set by the SDK (not overridable), and note that `CLAUDECODE` is filtered from the inherited environment.

Note: Go's behavior differs from TypeScript — here `Options.Env` merges on top of the system environment rather than replacing it. The TypeScript SDK had a bug where `CLAUDE_AGENT_SDK_VERSION` was dropped when a custom env was supplied; Go was never affected by this because the SDK-controlled vars are appended last (step 4 in the layered ordering).

Closes #251

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (docs-only change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjrCG4LjWhUjVNdDinStKo)_