### PR TITLE
feat: add PostToolBatch hook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `HookEventSessionEnd` (`"SessionEnd"`) hook event and `SessionEndHookInput` typed struct. Fires when a session ends (complements `SessionStart`). ([#252](https://github.com/Flohs/claude-agent-sdk-go/issues/252))
 - `HookEventStopFailure` (`"StopFailure"`) hook event and `StopFailureHookInput` typed struct. Fires when the Stop hook itself encounters an error. ([#252](https://github.com/Flohs/claude-agent-sdk-go/issues/252))
 - `HookEventPostCompact` (`"PostCompact"`) hook event and `PostCompactHookInput` typed struct with `Trigger` (`"manual"` or `"auto"`) and `CompactSummary` fields. Fires after a context compaction completes. ([#253](https://github.com/Flohs/claude-agent-sdk-go/issues/253))
+- `HookEventPostToolBatch` (`"PostToolBatch"`) hook event, `PostToolBatchHookInput` struct (field: `ToolCalls []PostToolBatchToolCall`), and `PostToolBatchToolCall` type (`ToolName`, `ToolInput`, `ToolUseID`, `ToolResponse`). Fires once after a batch of tool calls completes, as opposed to `PostToolUse` which fires per tool. ([#254](https://github.com/Flohs/claude-agent-sdk-go/issues/254))
 
 ### Documentation
 

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -155,6 +155,26 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			CompactSummary: stringField(input, "compact_summary"),
 		}, nil
 
+	case HookEventPostToolBatch:
+		var calls []PostToolBatchToolCall
+		if raw, ok := input["tool_calls"].([]any); ok {
+			calls = make([]PostToolBatchToolCall, 0, len(raw))
+			for _, item := range raw {
+				if m, ok := item.(map[string]any); ok {
+					calls = append(calls, PostToolBatchToolCall{
+						ToolName:     stringField(m, "tool_name"),
+						ToolInput:    mapField(m, "tool_input"),
+						ToolUseID:    stringField(m, "tool_use_id"),
+						ToolResponse: m["tool_response"],
+					})
+				}
+			}
+		}
+		return &PostToolBatchHookInput{
+			BaseHookInput: base,
+			ToolCalls:     calls,
+		}, nil
+
 	default:
 		// Forward-compatible: return nil for unrecognized events.
 		return nil, nil

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -28,6 +28,7 @@ var (
 	_ TypedHookInput = (*SessionEndHookInput)(nil)
 	_ TypedHookInput = (*StopFailureHookInput)(nil)
 	_ TypedHookInput = (*PostCompactHookInput)(nil)
+	_ TypedHookInput = (*PostToolBatchHookInput)(nil)
 )
 
 // base returns a HookInput with common fields pre-filled.
@@ -911,6 +912,44 @@ func TestParseHookInput_PostCompact(t *testing.T) {
 	}
 	if m.CompactSummary != "Session compacted after 50k tokens." {
 		t.Errorf("CompactSummary: got %q", m.CompactSummary)
+	}
+}
+
+func TestParseHookInput_PostToolBatch(t *testing.T) {
+	input := merge(base("PostToolBatch"), HookInput{
+		"tool_calls": []any{
+			map[string]any{
+				"tool_name":     "Bash",
+				"tool_input":    map[string]any{"command": "ls"},
+				"tool_use_id":   "toolu_1",
+				"tool_response": map[string]any{"content": "file.txt"},
+			},
+			map[string]any{
+				"tool_name":   "Read",
+				"tool_input":  map[string]any{"path": "/README.md"},
+				"tool_use_id": "toolu_2",
+			},
+		},
+	})
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(*PostToolBatchHookInput)
+	if !ok {
+		t.Fatalf("expected *PostToolBatchHookInput, got %T", result)
+	}
+	if len(m.ToolCalls) != 2 {
+		t.Fatalf("ToolCalls: got %d, want 2", len(m.ToolCalls))
+	}
+	if m.ToolCalls[0].ToolName != "Bash" {
+		t.Errorf("ToolCalls[0].ToolName: got %q, want 'Bash'", m.ToolCalls[0].ToolName)
+	}
+	if m.ToolCalls[0].ToolUseID != "toolu_1" {
+		t.Errorf("ToolCalls[0].ToolUseID: got %q, want 'toolu_1'", m.ToolCalls[0].ToolUseID)
+	}
+	if m.ToolCalls[1].ToolName != "Read" {
+		t.Errorf("ToolCalls[1].ToolName: got %q, want 'Read'", m.ToolCalls[1].ToolName)
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -45,6 +45,9 @@ const (
 	HookEventStopFailure HookEvent = "StopFailure"
 	// HookEventPostCompact fires after a context compaction completes.
 	HookEventPostCompact HookEvent = "PostCompact"
+	// HookEventPostToolBatch fires after a batch of tool calls completes.
+	// Unlike PostToolUse (which fires per tool), this fires once for the whole batch.
+	HookEventPostToolBatch HookEvent = "PostToolBatch"
 )
 
 // HookInput represents the input data for a hook callback.
@@ -323,6 +326,24 @@ type PostCompactHookInput struct {
 }
 
 func (*PostCompactHookInput) hookInputMarker() {}
+
+// PostToolBatchToolCall describes a single tool call in a [PostToolBatchHookInput].
+type PostToolBatchToolCall struct {
+	ToolName     string         `json:"tool_name"`
+	ToolInput    map[string]any `json:"tool_input"`
+	ToolUseID    string         `json:"tool_use_id"`
+	ToolResponse any            `json:"tool_response,omitempty"`
+}
+
+// PostToolBatchHookInput is the typed input for PostToolBatch hook events.
+// Fires once after a batch of tool calls completes.
+type PostToolBatchHookInput struct {
+	BaseHookInput
+	// ToolCalls is the list of tool calls that completed in this batch.
+	ToolCalls []PostToolBatchToolCall `json:"tool_calls"`
+}
+
+func (*PostToolBatchHookInput) hookInputMarker() {}
 
 // HookContext provides context for hook callbacks.
 type HookContext struct {


### PR DESCRIPTION
## Summary

Adds the `PostToolBatch` hook event that fires after a batch of parallel tool calls resolves, before the next model call.

- `HookEventPostToolBatch` (`"PostToolBatch"`) constant
- `PostToolBatchToolCall` struct with `ToolName`, `ToolInput`, `ToolUseID`, `ToolResponse` fields
- `PostToolBatchHookInput` struct with `BaseHookInput` and `ToolCalls []PostToolBatchToolCall`
- Parser case in `ParseHookInput`
- Round-trip tests

Closes #254

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjrCG4LjWhUjVNdDinStKo)_