### PR TITLE
feat: add PermissionDenied hook event with typed output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `HookEventStopFailure` (`"StopFailure"`) hook event and `StopFailureHookInput` typed struct. Fires when the Stop hook itself encounters an error. ([#252](https://github.com/Flohs/claude-agent-sdk-go/issues/252))
 - `HookEventPostCompact` (`"PostCompact"`) hook event and `PostCompactHookInput` typed struct with `Trigger` (`"manual"` or `"auto"`) and `CompactSummary` fields. Fires after a context compaction completes. ([#253](https://github.com/Flohs/claude-agent-sdk-go/issues/253))
 - `HookEventPostToolBatch` (`"PostToolBatch"`) hook event, `PostToolBatchHookInput` struct (field: `ToolCalls []PostToolBatchToolCall`), and `PostToolBatchToolCall` type (`ToolName`, `ToolInput`, `ToolUseID`, `ToolResponse`). Fires once after a batch of tool calls completes, as opposed to `PostToolUse` which fires per tool. ([#254](https://github.com/Flohs/claude-agent-sdk-go/issues/254))
+- `HookEventPermissionDenied` (`"PermissionDenied"`) hook event, `PermissionDeniedHookInput` struct (`ToolName`, `ToolInput`, `ToolUseID`, `Reason`), and `PermissionDeniedHookOutput` typed output with `Retry bool` and `ToHookJSONOutput()`. Fires when a tool call is blocked by a permission check; returning `Retry: true` asks the CLI to retry. ([#255](https://github.com/Flohs/claude-agent-sdk-go/issues/255))
 
 ### Documentation
 

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -175,6 +175,15 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			ToolCalls:     calls,
 		}, nil
 
+	case HookEventPermissionDenied:
+		return &PermissionDeniedHookInput{
+			BaseHookInput: base,
+			ToolName:      stringField(input, "tool_name"),
+			ToolInput:     mapField(input, "tool_input"),
+			ToolUseID:     stringField(input, "tool_use_id"),
+			Reason:        stringField(input, "reason"),
+		}, nil
+
 	default:
 		// Forward-compatible: return nil for unrecognized events.
 		return nil, nil

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -29,6 +29,7 @@ var (
 	_ TypedHookInput = (*StopFailureHookInput)(nil)
 	_ TypedHookInput = (*PostCompactHookInput)(nil)
 	_ TypedHookInput = (*PostToolBatchHookInput)(nil)
+	_ TypedHookInput = (*PermissionDeniedHookInput)(nil)
 )
 
 // base returns a HookInput with common fields pre-filled.
@@ -950,6 +951,45 @@ func TestParseHookInput_PostToolBatch(t *testing.T) {
 	}
 	if m.ToolCalls[1].ToolName != "Read" {
 		t.Errorf("ToolCalls[1].ToolName: got %q, want 'Read'", m.ToolCalls[1].ToolName)
+	}
+}
+
+func TestParseHookInput_PermissionDenied(t *testing.T) {
+	input := merge(base("PermissionDenied"), HookInput{
+		"tool_name":   "Bash",
+		"tool_input":  map[string]any{"command": "rm -rf /"},
+		"tool_use_id": "toolu_denied1",
+		"reason":      "command modifies system files",
+	})
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(*PermissionDeniedHookInput)
+	if !ok {
+		t.Fatalf("expected *PermissionDeniedHookInput, got %T", result)
+	}
+	if m.ToolName != "Bash" {
+		t.Errorf("ToolName: got %q, want 'Bash'", m.ToolName)
+	}
+	if m.ToolUseID != "toolu_denied1" {
+		t.Errorf("ToolUseID: got %q, want 'toolu_denied1'", m.ToolUseID)
+	}
+	if m.Reason != "command modifies system files" {
+		t.Errorf("Reason: got %q", m.Reason)
+	}
+}
+
+func TestPermissionDeniedHookOutput_ToHookJSONOutput(t *testing.T) {
+	out := PermissionDeniedHookOutput{Retry: true}
+	j := out.ToHookJSONOutput()
+	if j["retry"] != true {
+		t.Errorf("retry: got %v, want true", j["retry"])
+	}
+	empty := PermissionDeniedHookOutput{}
+	j2 := empty.ToHookJSONOutput()
+	if _, ok := j2["retry"]; ok {
+		t.Error("retry should be absent when false")
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -48,6 +48,8 @@ const (
 	// HookEventPostToolBatch fires after a batch of tool calls completes.
 	// Unlike PostToolUse (which fires per tool), this fires once for the whole batch.
 	HookEventPostToolBatch HookEvent = "PostToolBatch"
+	// HookEventPermissionDenied fires when a tool call is blocked by a permission check.
+	HookEventPermissionDenied HookEvent = "PermissionDenied"
 )
 
 // HookInput represents the input data for a hook callback.
@@ -295,6 +297,37 @@ func (o SessionStartHookOutput) ToHookJSONOutput() HookJSONOutput {
 	}
 	if o.SessionTitle != "" {
 		out["hookSpecificOutput"] = map[string]any{"sessionTitle": o.SessionTitle}
+	}
+	return out
+}
+
+// PermissionDeniedHookInput is the typed input for PermissionDenied hook events.
+// Fires when a tool call is blocked by a permission check.
+type PermissionDeniedHookInput struct {
+	BaseHookInput
+	// ToolName is the name of the tool that was denied.
+	ToolName string `json:"tool_name"`
+	// ToolInput contains the tool call arguments.
+	ToolInput map[string]any `json:"tool_input"`
+	// ToolUseID is the ID of the tool use that was denied.
+	ToolUseID string `json:"tool_use_id"`
+	// Reason is the human-readable reason for the denial.
+	Reason string `json:"reason"`
+}
+
+func (*PermissionDeniedHookInput) hookInputMarker() {}
+
+// PermissionDeniedHookOutput is the typed output for [HookEventPermissionDenied] callbacks.
+type PermissionDeniedHookOutput struct {
+	// Retry, when true, asks the CLI to retry the permission check.
+	Retry bool
+}
+
+// ToHookJSONOutput converts the typed struct to a [HookJSONOutput] map.
+func (o PermissionDeniedHookOutput) ToHookJSONOutput() HookJSONOutput {
+	out := HookJSONOutput{}
+	if o.Retry {
+		out["retry"] = true
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Adds the `PermissionDenied` hook event that fires when a tool call is blocked by auto-mode permission classification.

- `HookEventPermissionDenied` (`"PermissionDenied"`) constant
- `PermissionDeniedHookInput` struct with `ToolName`, `ToolInput`, `ToolUseID`, `Reason` fields
- `PermissionDeniedHookOutput` typed output struct with `Retry bool` and `ToHookJSONOutput()` helper — setting `Retry: true` asks the CLI to retry the permission check
- Parser case in `ParseHookInput`
- Round-trip tests

Closes #255

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjrCG4LjWhUjVNdDinStKo)_