### PR TITLE
feat: add ElicitationResult hook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `HookEventPostCompact` (`"PostCompact"`) hook event and `PostCompactHookInput` typed struct with `Trigger` (`"manual"` or `"auto"`) and `CompactSummary` fields. Fires after a context compaction completes. ([#253](https://github.com/Flohs/claude-agent-sdk-go/issues/253))
 - `HookEventPostToolBatch` (`"PostToolBatch"`) hook event, `PostToolBatchHookInput` struct (field: `ToolCalls []PostToolBatchToolCall`), and `PostToolBatchToolCall` type (`ToolName`, `ToolInput`, `ToolUseID`, `ToolResponse`). Fires once after a batch of tool calls completes, as opposed to `PostToolUse` which fires per tool. ([#254](https://github.com/Flohs/claude-agent-sdk-go/issues/254))
 - `HookEventPermissionDenied` (`"PermissionDenied"`) hook event, `PermissionDeniedHookInput` struct (`ToolName`, `ToolInput`, `ToolUseID`, `Reason`), and `PermissionDeniedHookOutput` typed output with `Retry bool` and `ToHookJSONOutput()`. Fires when a tool call is blocked by a permission check; returning `Retry: true` asks the CLI to retry. ([#255](https://github.com/Flohs/claude-agent-sdk-go/issues/255))
+- `HookEventElicitationResult` (`"ElicitationResult"`) hook event and `ElicitationResultHookInput` struct (`McpServerName`, `ElicitationID`, `Mode`, `Action`, `Content`). Fires when an MCP server elicitation request completes; complements `HookEventElicitation` which fires when the request is received. ([#256](https://github.com/Flohs/claude-agent-sdk-go/issues/256))
 
 ### Documentation
 

--- a/hook_input_parser.go
+++ b/hook_input_parser.go
@@ -184,6 +184,16 @@ func ParseHookInput(input HookInput) (TypedHookInput, error) {
 			Reason:        stringField(input, "reason"),
 		}, nil
 
+	case HookEventElicitationResult:
+		return &ElicitationResultHookInput{
+			BaseHookInput: base,
+			McpServerName: stringField(input, "mcp_server_name"),
+			ElicitationID: stringField(input, "elicitation_id"),
+			Mode:          stringField(input, "mode"),
+			Action:        stringField(input, "action"),
+			Content:       mapField(input, "content"),
+		}, nil
+
 	default:
 		// Forward-compatible: return nil for unrecognized events.
 		return nil, nil

--- a/hook_input_parser_test.go
+++ b/hook_input_parser_test.go
@@ -30,6 +30,7 @@ var (
 	_ TypedHookInput = (*PostCompactHookInput)(nil)
 	_ TypedHookInput = (*PostToolBatchHookInput)(nil)
 	_ TypedHookInput = (*PermissionDeniedHookInput)(nil)
+	_ TypedHookInput = (*ElicitationResultHookInput)(nil)
 )
 
 // base returns a HookInput with common fields pre-filled.
@@ -990,6 +991,33 @@ func TestPermissionDeniedHookOutput_ToHookJSONOutput(t *testing.T) {
 	j2 := empty.ToHookJSONOutput()
 	if _, ok := j2["retry"]; ok {
 		t.Error("retry should be absent when false")
+	}
+}
+
+func TestParseHookInput_ElicitationResult(t *testing.T) {
+	input := merge(base("ElicitationResult"), HookInput{
+		"mcp_server_name": "my-mcp",
+		"elicitation_id":  "elicit-42",
+		"mode":            "form",
+		"action":          "accept",
+		"content":         map[string]any{"api_key": "sk-test"},
+	})
+	result, err := ParseHookInput(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(*ElicitationResultHookInput)
+	if !ok {
+		t.Fatalf("expected *ElicitationResultHookInput, got %T", result)
+	}
+	if m.McpServerName != "my-mcp" {
+		t.Errorf("McpServerName: got %q, want 'my-mcp'", m.McpServerName)
+	}
+	if m.Action != "accept" {
+		t.Errorf("Action: got %q, want 'accept'", m.Action)
+	}
+	if m.Content["api_key"] != "sk-test" {
+		t.Errorf("Content: got %v", m.Content)
 	}
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -50,6 +50,9 @@ const (
 	HookEventPostToolBatch HookEvent = "PostToolBatch"
 	// HookEventPermissionDenied fires when a tool call is blocked by a permission check.
 	HookEventPermissionDenied HookEvent = "PermissionDenied"
+	// HookEventElicitationResult fires when an MCP server elicitation request
+	// completes (complements [HookEventElicitation] which fires when received).
+	HookEventElicitationResult HookEvent = "ElicitationResult"
 )
 
 // HookInput represents the input data for a hook callback.
@@ -377,6 +380,24 @@ type PostToolBatchHookInput struct {
 }
 
 func (*PostToolBatchHookInput) hookInputMarker() {}
+
+// ElicitationResultHookInput is the typed input for ElicitationResult hook events.
+// Fires when an MCP server elicitation request completes.
+type ElicitationResultHookInput struct {
+	BaseHookInput
+	// McpServerName is the name of the MCP server that initiated elicitation.
+	McpServerName string `json:"mcp_server_name"`
+	// ElicitationID is the identifier of the elicitation request (optional).
+	ElicitationID string `json:"elicitation_id,omitempty"`
+	// Mode is the elicitation mode: "form" or "url" (optional).
+	Mode string `json:"mode,omitempty"`
+	// Action is the user's response: "accept", "decline", or "cancel".
+	Action string `json:"action"`
+	// Content contains the user-provided form content when Action is "accept" (optional).
+	Content map[string]any `json:"content,omitempty"`
+}
+
+func (*ElicitationResultHookInput) hookInputMarker() {}
 
 // HookContext provides context for hook callbacks.
 type HookContext struct {


### PR DESCRIPTION
## Summary

Adds the `ElicitationResult` hook event that fires when an MCP server elicitation request completes (complements the existing `Elicitation` hook which fires when the request arrives).

- `HookEventElicitationResult` (`"ElicitationResult"`) constant
- `ElicitationResultHookInput` struct with `ServerName`, `ElicitationID`, `Mode`, `Action`, `Content` fields
- Parser case in `ParseHookInput`
- Round-trip tests

Closes #256

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjrCG4LjWhUjVNdDinStKo)_