### PR TITLE
docs: deprecate "Skill" string in AllowedTools in favor of Skills option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Documentation
 
+- Deprecated adding `"Skill"` to `Options.AllowedTools` directly. Use `Options.Skills` instead, which automatically injects the appropriate `AllowedTools` entries and defaults `SettingSources`. Port of Python SDK v0.1.77 ([#274](https://github.com/Flohs/claude-agent-sdk-go/issues/274))
 - `Options.Env`: expanded GoDoc to describe the four-layer merge order (SDK defaults → inherited `os.Environ()` → user-provided `Env` entries → SDK-controlled vars), clarify that `CLAUDE_AGENT_SDK_VERSION` is always set by the SDK and cannot be overridden via `Env`, and note that `CLAUDECODE` is filtered from the inherited env. Note that unlike the TypeScript SDK (where `options.env` replaces the subprocess environment), the Go SDK merges `Env` on top of the inherited environment. Port of TypeScript SDK v0.3.149. ([#251](https://github.com/Flohs/claude-agent-sdk-go/issues/251))
 
 ### Fixed

--- a/options.go
+++ b/options.go
@@ -192,6 +192,10 @@ type Options struct {
 	// without invoking the CanUseTool callback. Tools not in this list fall through
 	// to PermissionMode + CanUseTool evaluation. This is NOT an availability filter —
 	// it does not restrict which tools are available, only which are pre-approved.
+	//
+	// Deprecated: adding "Skill" to AllowedTools directly is deprecated. Use
+	// Options.Skills instead, which automatically injects the appropriate
+	// AllowedTools entries and defaults SettingSources.
 	AllowedTools []string
 	// SystemPrompt configures the system prompt. Use StringPrompt or PresetPrompt.
 	SystemPrompt SystemPrompt


### PR DESCRIPTION
Port of Python SDK v0.1.77 (PR anthropics/claude-agent-sdk-python#924).

Adds a GoDoc deprecation notice to `Options.AllowedTools` explaining that adding `"Skill"` entries directly is deprecated in favor of the `Options.Skills` field.

Closes #274

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNQ2VZBezoze4Bqq4WNPtC)_