### PR TITLE
feat: support list-form system prompt (ContentBlocksPrompt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `HookEventSetup` (`"Setup"`) hook event constant and `SetupHookInput` typed struct with `Trigger string` (`"init"` or `"maintenance"`). Fires during one-time session initialization via `--init-only` or `-p --init/--maintenance` flags. Hook output is written to the debug log only. ([#259](https://github.com/Flohs/claude-agent-sdk-go/issues/259))
 - `HookEventTaskCreated` (`"TaskCreated"`) hook event constant and `TaskCreatedHookInput` typed struct with `TaskName`, `TaskDescription`, and embedded `SubagentContext` fields. Fires when a new task is being created (e.g. via the TaskCreate tool). Returning `decision:"block"` rolls back the creation. ([#259](https://github.com/Flohs/claude-agent-sdk-go/issues/259))
 - `InheritEnv *bool` field on `Options`. When set to `false`, the CLI subprocess starts with a clean environment containing only SDK-required variables plus any entries from `Options.Env` (instead of inheriting the full parent process environment). Defaults to `true` (nil treated as true) for backward compatibility. Port of Python SDK PR anthropics/claude-agent-sdk-python#944. ([#278](https://github.com/Flohs/claude-agent-sdk-go/issues/278))
+- `ContentBlocksPrompt` type (`[]map[string]any`) implementing `SystemPrompt`. Allows passing a list of Anthropic content blocks as the system prompt. Serialized to a temporary JSON file and passed via `--system-prompt-file`. Port of Python SDK PRs anthropics/claude-agent-sdk-python#947 and #900. ([#283](https://github.com/Flohs/claude-agent-sdk-go/issues/283))
 
 ### Documentation
 

--- a/options.go
+++ b/options.go
@@ -79,6 +79,13 @@ type PresetPrompt struct {
 
 func (PresetPrompt) systemPromptMarker() {}
 
+// ContentBlocksPrompt is a system prompt expressed as an array of content blocks,
+// matching the Anthropic API's list-form system parameter.
+// Each block is a map with at minimum {"type": "text", "text": "..."}.
+type ContentBlocksPrompt []map[string]any
+
+func (ContentBlocksPrompt) systemPromptMarker() {}
+
 // ToolsPreset represents a tools preset configuration.
 type ToolsPreset struct {
 	Preset string `json:"preset"` // e.g. "claude_code"

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -127,6 +127,7 @@ type SubprocessTransport struct {
 	maxBufSize   int
 	mu           sync.Mutex
 	stdinClosed  bool
+	cleanupFuncs []func()
 }
 
 // NewSubprocessTransport creates a new subprocess transport.
@@ -349,6 +350,7 @@ func (t *SubprocessTransport) ReadMessages(ctx context.Context) <-chan map[strin
 			}
 			unregisterChild(cmd)
 		}
+		t.runCleanup()
 	}()
 
 	return ch
@@ -391,7 +393,20 @@ func (t *SubprocessTransport) Close() error {
 	t.stdout = nil
 	t.stdin = nil
 	t.stderr = nil
+
+	t.runCleanup()
+
 	return nil
+}
+
+// runCleanup executes and clears all registered cleanup functions.
+// Must be called without holding t.mu (cleanup functions may need to acquire it).
+func (t *SubprocessTransport) runCleanup() {
+	fns := t.cleanupFuncs
+	t.cleanupFuncs = nil
+	for _, fn := range fns {
+		fn()
+	}
 }
 
 // IsReady returns whether the transport is ready.
@@ -508,6 +523,24 @@ func (t *SubprocessTransport) buildCommand() []string {
 		case PresetPrompt:
 			if sp.Append != "" {
 				cmd = append(cmd, "--append-system-prompt", sp.Append)
+			}
+		case ContentBlocksPrompt:
+			data, err := json.Marshal([]map[string]any(sp))
+			if err == nil {
+				tmpFile, err := os.CreateTemp("", "claude-system-prompt-*.json")
+				if err == nil {
+					_, writeErr := tmpFile.Write(data)
+					closeErr := tmpFile.Close()
+					if writeErr == nil && closeErr == nil {
+						tmpPath := tmpFile.Name()
+						cmd = append(cmd, "--system-prompt-file", tmpPath)
+						t.cleanupFuncs = append(t.cleanupFuncs, func() {
+							_ = os.Remove(tmpPath)
+						})
+					} else {
+						_ = os.Remove(tmpFile.Name())
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Port of Python SDK PRs anthropics/claude-agent-sdk-python#947 and #900.\n\nAdds `ContentBlocksPrompt` (implements `SystemPrompt`) for passing an array of content blocks as the system prompt via `--system-prompt-file`.\n\nCloses #283

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNQ2VZBezoze4Bqq4WNPtC)_