### PR TITLE
fix(transport): inject Skill into --tools when explicit Tools list is set alongside Skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Fixed
 
+- `applySkillsDefaults` now also injects `"Skill"` into the `--tools` argument when `Options.Skills` is set and `Options.Tools` is an explicit `[]string`. Previously `Skill` was added to `--allowedTools` (auto-approve) but not to `--tools` (availability), so the model could never invoke any skill when an explicit tools list was provided. Port of Python SDK PR anthropics/claude-agent-sdk-python#985. ([#297](https://github.com/Flohs/claude-agent-sdk-go/issues/297))
 - Subprocess CLI errors now include the captured stderr tail (last ~8 KB) in the error message, making it much easier to diagnose failures such as missing API keys, invalid flags, or CLI crashes. Port of Python SDK PR anthropics/claude-agent-sdk-python#961. ([#282](https://github.com/Flohs/claude-agent-sdk-go/issues/282))
 - Forked session transcripts are now written atomically: all entries are staged in memory first and only committed to the `SessionStore` once the full set is ready. This prevents partial/corrupt forked sessions when a failure occurs mid-write. Port of Python SDK PR anthropics/claude-agent-sdk-python#960. ([#284](https://github.com/Flohs/claude-agent-sdk-go/issues/284))
 - Session resume now sanitizes `tool_use.id` values in the loaded transcript to conform to the `toolu_[a-zA-Z0-9_-]+` format required by the Claude API, preventing `400 Bad Request` errors when resuming sessions that contain bare UUIDs or IDs with invalid characters. Port of Python SDK PR anthropics/claude-agent-sdk-python#876. ([#281](https://github.com/Flohs/claude-agent-sdk-go/issues/281))
@@ -230,7 +231,7 @@ PRs.
 
 ### Changed
 
-- Minimum Claude CLI version bumped from `2.1.0` to `2.1.90` to align with Python SDK and ensure compatibility with v1.3.0 features (TaskBudget, ForkSession, DeleteSession, GetContextUsage, control_cancel_request, Errors on ResultMessage). ([#88](https://github.com/Flohs/claude-agent-sdk-go/issues/88))
+- Minimum Claude CLI version bumped from `2.1.0` to `2.1.90` to align with Python SDK and ensure compatibility with features like skills, memory, mcpServers in agent definitions, typed `RateLimitEvent`, and `GetSessionInfo` with `tag/created_at`. ([#88](https://github.com/Flohs/claude-agent-sdk-go/issues/88))
 - `sdkVersion` constant updated from `1.3.0` to `1.4.0`.
 
 ### Fixed

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -429,18 +429,17 @@ func (t *SubprocessTransport) EndInput() error {
 	return nil
 }
 
-// applySkillsDefaults computes the effective AllowedTools and SettingSources
-// when Options.Skills is set. When Skills is "all", it injects the bare Skill
-// tool; when it is a []string, it injects Skill(name) for each entry. In either
-// case SettingSources defaults to [user, project] if unset so the CLI
-// discovers installed skills without the caller having to wire both options
-// manually. Returns copies — the original options are not mutated.
-func applySkillsDefaults(opts *Options) ([]string, []SettingSource) {
+// applySkillsDefaults computes the effective AllowedTools, SettingSources, and
+// (when an explicit Tools list is provided) an effective Tools list when
+// Options.Skills is set. The third return value is the effective tools slice;
+// it is non-nil only when Skills injection appended "Skill" to a user-provided
+// []string Tools list. Returns copies — the original options are not mutated.
+func applySkillsDefaults(opts *Options) ([]string, []SettingSource, []string) {
 	allowed := append([]string(nil), opts.AllowedTools...)
 	settingSources := opts.SettingSources
 
 	if opts.Skills == nil {
-		return allowed, settingSources
+		return allowed, settingSources, nil
 	}
 
 	injected := false
@@ -466,7 +465,21 @@ func applySkillsDefaults(opts *Options) ([]string, []SettingSource) {
 		settingSources = []SettingSource{SettingSourceUser, SettingSourceProject}
 	}
 
-	return allowed, settingSources
+	// When Tools is an explicit []string, inject "Skill" there too so the CLI
+	// makes it available. --allowedTools alone only auto-approves it; the tool
+	// must also appear in --tools to be loadable by the model.
+	var effectiveTools []string
+	if injected {
+		if tools, ok := opts.Tools.([]string); ok {
+			effectiveTools = make([]string, len(tools))
+			copy(effectiveTools, tools)
+			if !stringSliceContains(effectiveTools, "Skill") {
+				effectiveTools = append(effectiveTools, "Skill")
+			}
+		}
+	}
+
+	return allowed, settingSources, effectiveTools
 }
 
 func stringSliceContains(s []string, target string) bool {
@@ -545,9 +558,15 @@ func (t *SubprocessTransport) buildCommand() []string {
 		}
 	}
 
-	// Tools
-	if opts.Tools != nil {
-		switch tools := opts.Tools.(type) {
+	effectiveAllowedTools, effectiveSettingSources, effectiveTools := applySkillsDefaults(opts)
+
+	// Tools — use effectiveTools when Skills injection appended "Skill" to the list.
+	var toolsValue any = opts.Tools
+	if effectiveTools != nil {
+		toolsValue = (any)(effectiveTools)
+	}
+	if toolsValue != nil {
+		switch tools := toolsValue.(type) {
 		case []string:
 			if len(tools) == 0 {
 				cmd = append(cmd, "--tools", "")
@@ -559,7 +578,6 @@ func (t *SubprocessTransport) buildCommand() []string {
 		}
 	}
 
-	effectiveAllowedTools, effectiveSettingSources := applySkillsDefaults(opts)
 	if len(effectiveAllowedTools) > 0 {
 		cmd = append(cmd, "--allowedTools", strings.Join(effectiveAllowedTools, ","))
 	}

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -561,9 +561,9 @@ func (t *SubprocessTransport) buildCommand() []string {
 	effectiveAllowedTools, effectiveSettingSources, effectiveTools := applySkillsDefaults(opts)
 
 	// Tools — use effectiveTools when Skills injection appended "Skill" to the list.
-	var toolsValue any = opts.Tools
+	toolsValue := opts.Tools
 	if effectiveTools != nil {
-		toolsValue = (any)(effectiveTools)
+		toolsValue = any(effectiveTools)
 	}
 	if toolsValue != nil {
 		switch tools := toolsValue.(type) {

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -441,6 +441,93 @@ func TestBuildCommand_Skills(t *testing.T) {
 		}
 		t.Error("--setting-sources not found")
 	})
+
+	t.Run("skills all with explicit tools injects Skill into --tools", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Tools:  []string{"Read", "Write"},
+				Skills: "all",
+			},
+		}
+		cmd := transport.buildCommand()
+		for i, a := range cmd {
+			if a == "--tools" && i+1 < len(cmd) {
+				v := cmd[i+1]
+				if !strings.Contains(v, "Read") || !strings.Contains(v, "Write") || !strings.Contains(v, "Skill") {
+					t.Errorf("expected --tools to contain Read,Write,Skill, got %s", v)
+				}
+				return
+			}
+		}
+		t.Error("--tools flag not found")
+	})
+
+	t.Run("skills list with explicit tools injects Skill into --tools", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Tools:  []string{"Read"},
+				Skills: []string{"pdf"},
+			},
+		}
+		cmd := transport.buildCommand()
+		for i, a := range cmd {
+			if a == "--tools" && i+1 < len(cmd) {
+				v := cmd[i+1]
+				if !strings.Contains(v, "Read") || !strings.Contains(v, "Skill") {
+					t.Errorf("expected --tools to contain Read,Skill, got %s", v)
+				}
+				return
+			}
+		}
+		t.Error("--tools flag not found")
+	})
+
+	t.Run("skills with nil tools does not emit --tools", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Skills: "all",
+			},
+		}
+		cmd := transport.buildCommand()
+		assertNotContainsFlag(t, cmd, "--tools")
+	})
+
+	t.Run("skills with preset tools does not change --tools value", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Tools:  &ToolsPreset{Preset: "claude_code"},
+				Skills: "all",
+			},
+		}
+		cmd := transport.buildCommand()
+		assertContains(t, cmd, "--tools", "default")
+	})
+
+	t.Run("Skill already in explicit tools is not duplicated", func(t *testing.T) {
+		transport := &SubprocessTransport{
+			cliPath: "claude",
+			options: &Options{
+				Tools:  []string{"Read", "Skill"},
+				Skills: "all",
+			},
+		}
+		cmd := transport.buildCommand()
+		for i, a := range cmd {
+			if a == "--tools" && i+1 < len(cmd) {
+				v := cmd[i+1]
+				count := strings.Count(v, "Skill")
+				if count != 1 {
+					t.Errorf("expected Skill to appear exactly once in --tools, got: %s", v)
+				}
+				return
+			}
+		}
+		t.Error("--tools flag not found")
+	})
 }
 
 func TestBuildSettingsValue_SandboxFailIfUnavailable(t *testing.T) {


### PR DESCRIPTION
Closing as superseded — already committed to main as `cc90c972a40115f8686fe7e1457a74708dfd892d`.