### PR TITLE
feat(types): add SupportsFastMode field to ServerCapabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `SupportsFastMode bool` field on `ServerCapabilities` (populated by `GetServerCapabilities()`). Set to `true` when the active model supports fast mode. Port of TypeScript SDK v0.2.69. ([#307](https://github.com/Flohs/claude-agent-sdk-go/issues/307))
 - `AdvisorToolConfig` struct (fields: `Model`, `MaxUses`, `Caching`, `AllowedCallers`) and `Advisor any` field on `AgentDefinition`. Set `Advisor` to `true` to enable the advisor tool with default config, or provide `*AdvisorToolConfig` for fine-grained control. Enables the executor/advisor pattern without dropping to the raw Anthropic SDK. Port of Python SDK PR anthropics/claude-agent-sdk-python#880. ([#279](https://github.com/Flohs/claude-agent-sdk-go/issues/279))
 - `AlwaysLoad bool` field (`json:"alwaysLoad,omitempty"`) on `McpStdioServerConfig`, `McpSSEServerConfig`, and `McpHTTPServerConfig`. When `true`, the CLI waits for the server to connect before executing the first query (blocking behavior). By default servers connect in the background since CLI v2.1.142. Port of TypeScript SDK v0.3.142. ([#272](https://github.com/Flohs/claude-agent-sdk-go/issues/272))
 - `SandboxFilesystemConfig` struct with fields `AllowWrite`, `DenyWrite`, `DenyRead`, `AllowRead`, and `AllowManagedReadPathsOnly` for controlling filesystem access in sandboxed commands. Port of Python SDK PR anthropics/claude-agent-sdk-python#862. ([#280](https://github.com/Flohs/claude-agent-sdk-go/issues/280))

--- a/client.go
+++ b/client.go
@@ -462,6 +462,9 @@ func (c *Client) GetServerCapabilities() *ServerCapabilities {
 	if v, ok := c.q.initializationResult["supportsAdaptiveThinking"].(bool); ok {
 		caps.SupportsAdaptiveThinking = v
 	}
+	if v, ok := c.q.initializationResult["supportsFastMode"].(bool); ok {
+		caps.SupportsFastMode = v
+	}
 	if levels, ok := c.q.initializationResult["supportedEffortLevels"].([]any); ok {
 		for _, l := range levels {
 			if s, ok := l.(string); ok {

--- a/types.go
+++ b/types.go
@@ -556,6 +556,8 @@ type ServerCapabilities struct {
 	// SupportsAdaptiveThinking is true when the model supports adaptive
 	// thinking mode (ThinkingConfigAdaptive).
 	SupportsAdaptiveThinking bool `json:"supportsAdaptiveThinking"`
+	// SupportsFastMode is true when the current model supports fast mode.
+	SupportsFastMode bool `json:"supportsFastMode"`
 	// MemoryPaths is the list of memory file paths loaded at session initialization.
 	// Empty when no memory files are configured.
 	MemoryPaths []string `json:"memoryPaths,omitempty"`


### PR DESCRIPTION
Closing as superseded — already committed to main as `2bfdf8ea5871567733114c176c48aa8e91297a82`.