### PR TITLE
feat(query): dispatch pending_permission_requests and make initialize idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Fixed
 
+- `sendControlRequest` now dispatches `pending_permission_requests` entries included in control responses as synthetic control requests, ensuring permission hook callbacks fire for requests queued before the session loop was running. Port of TypeScript SDK v0.3.161. ([#309](https://github.com/Flohs/claude-agent-sdk-go/issues/309))
+- `initialize` control request is now handled idempotently: if the CLI returns an "already initialized" error on a repeated call, the SDK treats it as success and reuses the stored initialization result. Port of TypeScript SDK v0.3.161. ([#309](https://github.com/Flohs/claude-agent-sdk-go/issues/309))
 - Subprocess CLI errors now include the captured stderr tail (last ~8 KB) in the error message, making it much easier to diagnose failures such as missing API keys, invalid flags, or CLI crashes. Port of Python SDK PR anthropics/claude-agent-sdk-python#961. ([#282](https://github.com/Flohs/claude-agent-sdk-go/issues/282))
 - Forked session transcripts are now written atomically: all entries are staged in memory first and only committed to the `SessionStore` once the full set is ready. This prevents partial/corrupt forked sessions when a failure occurs mid-write. Port of Python SDK PR anthropics/claude-agent-sdk-python#960. ([#284](https://github.com/Flohs/claude-agent-sdk-go/issues/284))
 - Session resume now sanitizes `tool_use.id` values in the loaded transcript to conform to the `toolu_[a-zA-Z0-9_-]+` format required by the Claude API, preventing `400 Bad Request` errors when resuming sessions that contain bare UUIDs or IDs with invalid characters. Port of Python SDK PR anthropics/claude-agent-sdk-python#876. ([#281](https://github.com/Flohs/claude-agent-sdk-go/issues/281))

--- a/query.go
+++ b/query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -629,6 +630,14 @@ func (q *query) initialize() (map[string]any, error) {
 
 	response, err := q.sendControlRequest(request, time.Duration(q.initTimeout*float64(time.Second)))
 	if err != nil {
+		// Treat repeated initialize as idempotent (CLI returns "already initialized" error
+		// for sessions that were already set up). Port of TypeScript SDK v0.3.161.
+		if strings.Contains(strings.ToLower(err.Error()), "already initialized") {
+			if q.initializationResult != nil {
+				return q.initializationResult, nil
+			}
+			return map[string]any{}, nil
+		}
 		return nil, err
 	}
 
@@ -681,6 +690,15 @@ func (q *query) sendControlRequest(request map[string]any, timeout time.Duration
 		responseData, _ := resp["response"].(map[string]any)
 		if responseData == nil {
 			responseData = map[string]any{}
+		}
+
+		// Dispatch any pending permission requests piggybacked on the response.
+		if pending, ok := resp["pending_permission_requests"].([]any); ok {
+			for _, pr := range pending {
+				if prMap, ok := pr.(map[string]any); ok {
+					go q.handleControlRequest(prMap)
+				}
+			}
 		}
 		return responseData, nil
 


### PR DESCRIPTION
Closing as superseded — already committed to main as `ee7f0e68250fe0e064e4eecac05861c1b8364ab7`.