### PR TITLE
docs(permissions): clarify CanUseTool fires only on ask decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - Deprecated adding `"Skill"` to `Options.AllowedTools` directly. Use `Options.Skills` instead, which automatically injects the appropriate `AllowedTools` entries and defaults `SettingSources`. Port of Python SDK v0.1.77 ([#274](https://github.com/Flohs/claude-agent-sdk-go/issues/274))
 - `Options.Env`: expanded GoDoc to describe the four-layer merge order (SDK defaults → inherited `os.Environ()` → user-provided `Env` entries → SDK-controlled vars), clarify that `CLAUDE_AGENT_SDK_VERSION` is always set by the SDK and cannot be overridden via `Env`, and note that `CLAUDECODE` is filtered from the inherited env. Note that unlike the TypeScript SDK (where `options.env` replaces the subprocess environment), the Go SDK merges `Env` on top of the inherited environment. Port of TypeScript SDK v0.3.149. ([#251](https://github.com/Flohs/claude-agent-sdk-go/issues/251))
+- `CanUseToolFunc` and `Options.CanUseTool` GoDoc updated to clarify that the callback fires **only** when the CLI's permission evaluation resolves to `"ask"` — not for every tool use. Pre-approved tools (via `AllowedTools`, `PermissionMode`, or allow rules) and pre-denied tools (via `DisallowedTools` or deny rules) bypass this callback entirely. Use a `PreToolUse` hook for a universal per-tool interceptor. Port of Python SDK PR anthropics/claude-agent-sdk-python#912. ([#330](https://github.com/Flohs/claude-agent-sdk-go/issues/330))
 
 ### Fixed
 

--- a/options.go
+++ b/options.go
@@ -314,8 +314,12 @@ type Options struct {
 	MaxBufferSize *int
 	// Stderr is a callback for stderr output from the CLI.
 	Stderr func(string)
-	// CanUseTool is a callback invoked for tool permission decisions when a tool
-	// is not matched by AllowedTools or DisallowedTools.
+	// CanUseTool is a callback invoked for tool permission decisions, but only
+	// when the CLI's internal permission evaluation resolves to "ask" — i.e. the
+	// tool is not already permitted by AllowedTools, PermissionMode, or
+	// permissions.allow/deny rules. It is NOT called for every tool use. For a
+	// universal pre-tool interceptor, use a PreToolUse hook instead. See
+	// [CanUseToolFunc] for full details.
 	CanUseTool CanUseToolFunc
 	// Hooks configures hook callbacks.
 	Hooks map[HookEvent][]HookMatcher

--- a/permissions.go
+++ b/permissions.go
@@ -160,5 +160,20 @@ func parsePermissionUpdate(m map[string]any) PermissionUpdate {
 }
 
 // CanUseToolFunc is the callback type for tool permission decisions.
-// It is invoked for tools not matched by AllowedTools or DisallowedTools.
+//
+// Important: this callback is invoked only when the CLI's internal permission
+// evaluation resolves to "ask" — i.e. the tool was not already approved or
+// denied by AllowedTools, PermissionMode, or permissions.allow/deny rules in
+// the user/project settings. It is NOT called for every tool use.
+//
+//   - If a tool is pre-approved (via AllowedTools, PermissionMode
+//     BypassPermissions, or an allow rule), this callback is skipped entirely.
+//   - If a tool is pre-denied (via DisallowedTools or a deny rule), this
+//     callback is also skipped.
+//
+// For a universal pre-tool interceptor that fires on every tool call regardless
+// of the permission decision, use a PreToolUse hook instead.
+//
+// When this callback is invoked, ToolPermissionContext.ToolUseID is always
+// non-empty.
 type CanUseToolFunc func(ctx context.Context, toolName string, input map[string]any, permCtx ToolPermissionContext) (PermissionResult, error)


### PR DESCRIPTION
Superseded by #355 (newer implementation from 2026-06-11).