### PR TITLE
docs(permissions): clarify CanUseToolFunc fires only when CLI decision is "ask"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Documentation
 
+- `CanUseToolFunc` and `Options.CanUseTool`: clarified in GoDoc that the callback fires only when the CLI's internal permission decision is `"ask"` — it is not invoked for tools already permitted by `AllowedTools`, `PermissionMode`, or `permissions.allow` rules. For a universal pre-tool interceptor, use a `PreToolUse` hook instead. `ToolPermissionContext.ToolUseID` is always non-empty when delivered via this callback. Port of Python SDK PR anthropics/claude-agent-sdk-python#912. ([#330](https://github.com/Flohs/claude-agent-sdk-go/issues/330))
 - Deprecated adding `"Skill"` to `Options.AllowedTools` directly. Use `Options.Skills` instead, which automatically injects the appropriate `AllowedTools` entries and defaults `SettingSources`. Port of Python SDK v0.1.77 ([#274](https://github.com/Flohs/claude-agent-sdk-go/issues/274))
 - `Options.Env`: expanded GoDoc to describe the four-layer merge order (SDK defaults → inherited `os.Environ()` → user-provided `Env` entries → SDK-controlled vars), clarify that `CLAUDE_AGENT_SDK_VERSION` is always set by the SDK and cannot be overridden via `Env`, and note that `CLAUDECODE` is filtered from the inherited env. Note that unlike the TypeScript SDK (where `options.env` replaces the subprocess environment), the Go SDK merges `Env` on top of the inherited environment. Port of TypeScript SDK v0.3.149. ([#251](https://github.com/Flohs/claude-agent-sdk-go/issues/251))
 

--- a/options.go
+++ b/options.go
@@ -314,8 +314,10 @@ type Options struct {
 	MaxBufferSize *int
 	// Stderr is a callback for stderr output from the CLI.
 	Stderr func(string)
-	// CanUseTool is a callback invoked for tool permission decisions when a tool
-	// is not matched by AllowedTools or DisallowedTools.
+	// CanUseTool is invoked when the CLI's permission decision is "ask" for a
+	// tool call, replacing the interactive permission prompt. It is NOT called for
+	// tools already permitted by AllowedTools or PermissionMode — use a PreToolUse
+	// hook to observe every tool call regardless of permission settings.
 	CanUseTool CanUseToolFunc
 	// Hooks configures hook callbacks.
 	Hooks map[HookEvent][]HookMatcher

--- a/permissions.go
+++ b/permissions.go
@@ -159,6 +159,15 @@ func parsePermissionUpdate(m map[string]any) PermissionUpdate {
 	return p
 }
 
-// CanUseToolFunc is the callback type for tool permission decisions.
-// It is invoked for tools not matched by AllowedTools or DisallowedTools.
+// CanUseToolFunc is called when the CLI's permission evaluation resolves to
+// "ask" for a tool call — that is, when the tool is not already permitted by
+// AllowedTools, DisallowedTools, PermissionMode, or the allow/deny rules in
+// settings. It replaces the interactive permission prompt.
+//
+// CanUseToolFunc is NOT a universal tool interceptor: it does not fire for
+// tools that are pre-approved or pre-denied. Use a PreToolUse hook to observe
+// or gate every tool call regardless of permission settings.
+//
+// ToolPermissionContext.ToolUseID is always non-empty when delivered via
+// CanUseTool. Port of Python SDK PR anthropics/claude-agent-sdk-python#912.
 type CanUseToolFunc func(ctx context.Context, toolName string, input map[string]any, permCtx ToolPermissionContext) (PermissionResult, error)


### PR DESCRIPTION
Closing as duplicate of #355 which covers the same change on branch `docs/issue-330-can-use-tool`.