### PR TITLE
chore: release v2.2.0 (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-24
+
 ### Added
 
 - `ServerToolReadMcpResource` (`"read_mcp_resource"`) and `ServerToolReadMcpResourceDir` (`"read_mcp_resource_dir"`) constants added to the `ServerToolName` block. `ServerToolReadMcpResourceDir` is a dedicated tool for MCP resource directory listing, previously a fallback inside `ReadMcpResourceTool`. Port of TypeScript SDK v0.3.186. ([#437](https://github.com/Flohs/claude-agent-sdk-go/issues/437))

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -80,7 +80,7 @@ func init() {
 const (
 	defaultMaxBufferSize     = 1024 * 1024 // 1MB
 	minimumClaudeCodeVersion = "2.1.90"
-	sdkVersion               = "2.0.0"
+	sdkVersion               = "2.2.0"
 
 	// stderrMaxBytes caps the rolling stderr buffer at ~8 KB.
 	stderrMaxBytes = 8 * 1024


### PR DESCRIPTION
Closes #443

## Summary
- Finalize `CHANGELOG.md`: move all `[Unreleased]` entries into a new `## [2.2.0] - 2026-06-24` section and add a fresh empty `[Unreleased]` header.
- Bump `sdkVersion` in `subprocess_transport.go` from `2.0.0` to `2.2.0` (the constant was stale — it was never bumped for the v2.1.0 release).

## Versioning rationale
The `[Unreleased]` section contained only `Added`, `Documentation`, and `Fixed` entries — all backward-compatible with no breaking changes — so this is a minor bump from v2.1.0.

After merge, tagging `v2.2.0` will trigger `release.yml`, which extracts the `## [2.2.0]` changelog section and publishes the GitHub release.

## Test plan
- [x] `go build ./...` (clean, in golang:1.26 container)
- [x] `go test -race ./...` (pass)
- [x] `go vet ./...` (clean)