### PR TITLE
fix: correct Go module path to /v2 (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-24
+
+### Changed
+
+- **Module path:** the Go module path is now `github.com/Flohs/claude-agent-sdk-go/v2` (was `github.com/Flohs/claude-agent-sdk-go`), as required by Go's [semantic import versioning](https://go.dev/ref/mod#major-version-suffixes) for major version 2 and above. Releases v2.0.0–v2.2.0 declared the bare path and were therefore not installable (`go get` failed with `module path must match major version "…/v2"`); v2.3.0 is the first installable v2 release. Consumers must import `github.com/Flohs/claude-agent-sdk-go/v2` and install with `go get github.com/Flohs/claude-agent-sdk-go/v2@v2.3.0`. Example modules, the README, and the pkg.go.dev badge were updated to the new path. ([#445](https://github.com/Flohs/claude-agent-sdk-go/issues/445))
+
 ## [2.2.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Claude Agent SDK for Go
 
 [![CI](https://github.com/Flohs/claude-agent-sdk-go/actions/workflows/ci.yml/badge.svg)](https://github.com/Flohs/claude-agent-sdk-go/actions/workflows/ci.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/Flohs/claude-agent-sdk-go.svg)](https://pkg.go.dev/github.com/Flohs/claude-agent-sdk-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Flohs/claude-agent-sdk-go/v2.svg)](https://pkg.go.dev/github.com/Flohs/claude-agent-sdk-go/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Go SDK for Claude Agent. Communicates with the [Claude Code CLI](https://code.claude.com/docs) via subprocess stdio using a JSON-based bidirectional control protocol.
@@ -9,7 +9,7 @@ Go SDK for Claude Agent. Communicates with the [Claude Code CLI](https://code.cl
 ## Installation
 
 ```bash
-go get github.com/Flohs/claude-agent-sdk-go
+go get github.com/Flohs/claude-agent-sdk-go/v2
 ```
 
 **Prerequisites:**
@@ -37,7 +37,7 @@ import (
     "context"
     "fmt"
 
-    claude "github.com/Flohs/claude-agent-sdk-go"
+    claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func main() {

--- a/examples/agents/main.go
+++ b/examples/agents/main.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/budget/main.go
+++ b/examples/budget/main.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/filesystem_agents/main.go
+++ b/examples/filesystem_agents/main.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"strings"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/include_partial_messages/main.go
+++ b/examples/include_partial_messages/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func main() {

--- a/examples/mcp_calculator/main.go
+++ b/examples/mcp_calculator/main.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"math"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/multimodal_input/main.go
+++ b/examples/multimodal_input/main.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"os"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func imageInputExample(ctx context.Context) {

--- a/examples/plugins/main.go
+++ b/examples/plugins/main.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"path/filepath"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/quick_start/main.go
+++ b/examples/quick_start/main.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func basicExample(ctx context.Context) {

--- a/examples/session_store/main.go
+++ b/examples/session_store/main.go
@@ -33,7 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 // faultyStore wraps a SessionStore and starts returning an error from

--- a/examples/session_store_filesystem/filestore.go
+++ b/examples/session_store_filesystem/filestore.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 // FileSystemSessionStore is a pure-Go reference SessionStore adapter that

--- a/examples/session_store_filesystem/main.go
+++ b/examples/session_store_filesystem/main.go
@@ -34,7 +34,7 @@ import (
 	"path/filepath"
 	"time"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 // fakeEntry constructs a minimal SessionStoreEntry that round-trips

--- a/examples/session_stores/postgres/adapter.go
+++ b/examples/session_stores/postgres/adapter.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"time"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )

--- a/examples/session_stores/postgres/go.mod
+++ b/examples/session_stores/postgres/go.mod
@@ -3,8 +3,8 @@ module github.com/Flohs/claude-agent-sdk-go/examples/session_stores/postgres
 go 1.26.1
 
 require (
-	github.com/Flohs/claude-agent-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/Flohs/claude-agent-sdk-go/v2 v2.0.0-00010101000000-000000000000
 	github.com/jackc/pgx/v5 v5.7.4
 )
 
-replace github.com/Flohs/claude-agent-sdk-go => ../../../
+replace github.com/Flohs/claude-agent-sdk-go/v2 => ../../../

--- a/examples/session_stores/postgres/main.go
+++ b/examples/session_stores/postgres/main.go
@@ -17,7 +17,7 @@ import (
 	"log"
 	"os"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 

--- a/examples/session_stores/redis/adapter.go
+++ b/examples/session_stores/redis/adapter.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/examples/session_stores/redis/go.mod
+++ b/examples/session_stores/redis/go.mod
@@ -3,8 +3,8 @@ module github.com/Flohs/claude-agent-sdk-go/examples/session_stores/redis
 go 1.26.1
 
 require (
-	github.com/Flohs/claude-agent-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/Flohs/claude-agent-sdk-go/v2 v2.0.0-00010101000000-000000000000
 	github.com/redis/go-redis/v9 v9.7.3
 )
 
-replace github.com/Flohs/claude-agent-sdk-go => ../../../
+replace github.com/Flohs/claude-agent-sdk-go/v2 => ../../../

--- a/examples/session_stores/redis/main.go
+++ b/examples/session_stores/redis/main.go
@@ -17,7 +17,7 @@ import (
 	"log"
 	"os"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/examples/session_stores/s3/adapter.go
+++ b/examples/session_stores/s3/adapter.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 // S3SessionStore is a [claude.SessionStore] backed by Amazon S3.

--- a/examples/session_stores/s3/go.mod
+++ b/examples/session_stores/s3/go.mod
@@ -3,10 +3,10 @@ module github.com/Flohs/claude-agent-sdk-go/examples/session_stores/s3
 go 1.26.1
 
 require (
-	github.com/Flohs/claude-agent-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/Flohs/claude-agent-sdk-go/v2 v2.0.0-00010101000000-000000000000
 	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.5
 )
 
-replace github.com/Flohs/claude-agent-sdk-go => ../../../
+replace github.com/Flohs/claude-agent-sdk-go/v2 => ../../../

--- a/examples/session_stores/s3/main.go
+++ b/examples/session_stores/s3/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func main() {

--- a/examples/setting_sources/main.go
+++ b/examples/setting_sources/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/stderr_callback/main.go
+++ b/examples/stderr_callback/main.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func main() {

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"time"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/system_prompt/main.go
+++ b/examples/system_prompt/main.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/tool_permissions/main.go
+++ b/examples/tool_permissions/main.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"strings"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/examples/tools_option/main.go
+++ b/examples/tools_option/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	claude "github.com/Flohs/claude-agent-sdk-go"
+	claude "github.com/Flohs/claude-agent-sdk-go/v2"
 )
 
 func displayMessage(msg claude.Message) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Flohs/claude-agent-sdk-go
+module github.com/Flohs/claude-agent-sdk-go/v2
 
 go 1.26.1
 

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -80,7 +80,7 @@ func init() {
 const (
 	defaultMaxBufferSize     = 1024 * 1024 // 1MB
 	minimumClaudeCodeVersion = "2.1.90"
-	sdkVersion               = "2.2.0"
+	sdkVersion               = "2.3.0"
 
 	// stderrMaxBytes caps the rolling stderr buffer at ~8 KB.
 	stderrMaxBytes = 8 * 1024


### PR DESCRIPTION
Closes #445

## Problem
The module declared `module github.com/Flohs/claude-agent-sdk-go` but ships at v2.x tags. Go's semantic import versioning requires the path to end in `/v2` for major version 2+, so the package was **not installable**:
```
go: github.com/Flohs/claude-agent-sdk-go@v2.2.0: invalid version: module contains a go.mod file,
so module path must match major version ("github.com/Flohs/claude-agent-sdk-go/v2")
```
This affected v2.0.0, v2.1.0, and v2.2.0 equally.

## Fix
- `go.mod`: module path → `github.com/Flohs/claude-agent-sdk-go/v2`
- All 25 example `.go` imports rewritten to the `/v2` path
- The three `session_stores` example modules: `require`/`replace` directives updated to `/v2`
- README install/import examples and the pkg.go.dev badge updated to `/v2`
- `sdkVersion` bumped to `2.3.0`; `CHANGELOG.md` `[2.3.0]` entry added

After this, consumers install with `go get github.com/Flohs/claude-agent-sdk-go/v2@v2.3.0` and import `github.com/Flohs/claude-agent-sdk-go/v2`. v2.3.0 is the first installable v2 release.

## Verification (golang:1.26 container)
- [x] Root module `go build` / `go vet` / `go test -race` — all pass with the `/v2` path
- [x] `go list -m` reports `github.com/Flohs/claude-agent-sdk-go/v2`
- [x] `go mod tidy` clean (no diff)
- [x] redis & postgres example modules build with the `/v2` wiring

## Note (pre-existing, out of scope)
The `s3` example module fails to build due to a pre-existing unresolvable pinned dependency (`aws-sdk-go-v2/service/s3@v1.79.5: unknown revision`) — unrelated to the module path; its `/v2` wiring is identical to the modules that build. These example modules have no committed `go.sum` and are not built by CI.