### PR TITLE
feat(types): add typed NotebookEditToolInput and NotebookEditResult with old_source field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `NotebookEditOperation` string type with constants `NotebookEditOperationReplace` (`"replace"`), `NotebookEditOperationInsert` (`"insert"`), `NotebookEditOperationInsertAfter` (`"insert_after"`), and `NotebookEditOperationDelete` (`"delete"`). `NotebookEditToolInput` struct (`NotebookPath`, `CellID`, `EditMode NotebookEditOperation`, `NewSource`, `CellType`) for use with `PreToolUseHookInput.ToolInput` when `ToolName` is `"NotebookEdit"`. `NotebookEditResult` struct with `OldSource string` (populated for replace and delete operations; empty for insert and insert_after). Port of TypeScript SDK v0.3.191. ([#447](https://github.com/Flohs/claude-agent-sdk-go/issues/447))
+
 ## [2.3.0] - 2026-06-24
 
 ### Changed

--- a/types.go
+++ b/types.go
@@ -355,6 +355,45 @@ type ExitPlanModeToolInput struct {
 	PlanFilePath string `json:"planFilePath,omitempty"`
 }
 
+// NotebookEditOperation specifies which edit operation to perform on a notebook cell.
+// Port of TypeScript SDK v0.3.191.
+type NotebookEditOperation string
+
+const (
+	// NotebookEditOperationReplace replaces the content of an existing cell.
+	NotebookEditOperationReplace NotebookEditOperation = "replace"
+	// NotebookEditOperationInsert inserts a new cell before the target cell.
+	NotebookEditOperationInsert NotebookEditOperation = "insert"
+	// NotebookEditOperationInsertAfter inserts a new cell after the target cell.
+	NotebookEditOperationInsertAfter NotebookEditOperation = "insert_after"
+	// NotebookEditOperationDelete deletes the target cell.
+	NotebookEditOperationDelete NotebookEditOperation = "delete"
+)
+
+// NotebookEditToolInput is the typed input for the NotebookEdit tool.
+// Accessible from [PreToolUseHookInput].ToolInput when ToolName is "NotebookEdit".
+// Port of TypeScript SDK v0.3.191.
+type NotebookEditToolInput struct {
+	// NotebookPath is the filesystem path to the Jupyter notebook file.
+	NotebookPath string `json:"notebook_path"`
+	// CellID identifies the target cell by its notebook-assigned identifier.
+	CellID string `json:"cell_id"`
+	// EditMode specifies the operation to perform on the cell.
+	EditMode NotebookEditOperation `json:"edit_mode"`
+	// NewSource is the replacement source text. Required for replace, insert, and insert_after.
+	NewSource string `json:"new_source,omitempty"`
+	// CellType is the type of cell to create ("code" or "markdown"). Used for insert/insert_after.
+	CellType string `json:"cell_type,omitempty"`
+}
+
+// NotebookEditResult is the result returned by the NotebookEdit tool.
+// Port of TypeScript SDK v0.3.191.
+type NotebookEditResult struct {
+	// OldSource contains the prior cell content before the edit. Present only for
+	// replace and delete operations; empty for insert and insert_after.
+	OldSource string `json:"old_source,omitempty"`
+}
+
 // TaskCreateInput is the input schema for the TaskCreate tool.
 type TaskCreateInput struct {
 	Subject     string         `json:"subject"`


### PR DESCRIPTION
Port of TypeScript SDK v0.3.191.

Adds three new types for working with the `NotebookEdit` tool in hooks:

- `NotebookEditOperation` string type with constants `NotebookEditOperationReplace`, `NotebookEditOperationInsert`, `NotebookEditOperationInsertAfter`, `NotebookEditOperationDelete`
- `NotebookEditToolInput` struct — typed input for use in `PreToolUseHookInput.ToolInput` when `ToolName` is `"NotebookEdit"`
- `NotebookEditResult` struct — carries `OldSource string` populated for replace and delete operations; empty for insert and insert_after

Closes #447

---
_Generated by [Claude Code](https://claude.ai/code/session_019XDuDDuvZuzfBSVSQ8z1Yr)_