### PR TITLE
fix(subprocess): suppress console window flash on Windows when spawning CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- On Windows, spawning the CLI subprocess no longer flashes a brief console window. `SubprocessTransport.Connect` now sets `cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}` (Windows-only, isolated via build tags) before calling `cmd.Start()`. Port of TypeScript SDK v0.3.193. ([#453](https://github.com/Flohs/claude-agent-sdk-go/issues/453))
+
 ### Added
 
 - `NotebookEditOperation` string type with constants `NotebookEditOperationReplace` (`"replace"`), `NotebookEditOperationInsert` (`"insert"`), `NotebookEditOperationInsertAfter` (`"insert_after"`), and `NotebookEditOperationDelete` (`"delete"`). `NotebookEditToolInput` struct (`NotebookPath`, `CellID`, `EditMode NotebookEditOperation`, `NewSource`, `CellType`) for use with `PreToolUseHookInput.ToolInput` when `ToolName` is `"NotebookEdit"`. `NotebookEditResult` struct with `OldSource string` (populated for replace and delete operations; empty for insert and insert_after). Port of TypeScript SDK v0.3.191. ([#447](https://github.com/Flohs/claude-agent-sdk-go/issues/447))

--- a/subprocess_other.go
+++ b/subprocess_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package claude
+
+import "os/exec"
+
+func setPlatformProcAttr(cmd *exec.Cmd) {}

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -227,6 +227,7 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		return &ConnectionError{SDKError: SDKError{Message: fmt.Sprintf("Failed to create stderr pipe: %v", err)}}
 	}
 
+	setPlatformProcAttr(cmd)
 	if err := cmd.Start(); err != nil {
 		if t.cwd != "" {
 			if _, statErr := os.Stat(t.cwd); os.IsNotExist(statErr) {

--- a/subprocess_windows.go
+++ b/subprocess_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package claude
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setPlatformProcAttr suppresses the brief console-window flash that occurs on
+// Windows when a new process is spawned without explicit process-creation flags.
+// Port of TypeScript SDK v0.3.193.
+func setPlatformProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}


### PR DESCRIPTION
Port of TypeScript SDK v0.3.193.

On Windows, `exec.Command` without explicit process-creation flags causes a brief console window to flash each time the CLI subprocess is started. The TypeScript SDK fixed this in v0.3.193 by passing `windowsHide: true`; the Go equivalent is `SysProcAttr.HideWindow = true`.

Because `syscall.SysProcAttr.HideWindow` is a Windows-only field, the implementation uses build-tag-separated stubs:

- `subprocess_windows.go` (`//go:build windows`) — sets `cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}` via `setPlatformProcAttr`
- `subprocess_other.go` (`//go:build !windows`) — no-op stub

`SubprocessTransport.Connect` calls `setPlatformProcAttr(cmd)` just before `cmd.Start()`.

Closes #453