### PR TITLE
fix(message_parser): improve error message for non-list assistant content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - On Windows, spawning the CLI subprocess no longer flashes a brief console window. `SubprocessTransport.Connect` now sets `cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}` (Windows-only, isolated via build tags) before calling `cmd.Start()`. Port of TypeScript SDK v0.3.193. ([#453](https://github.com/Flohs/claude-agent-sdk-go/issues/453))
+- `parseAssistantMessage` now distinguishes a missing `content` field from a present-but-wrong-type field. A `nil` or absent key returns `"Missing 'content' field in assistant message"` as before; a non-nil value that is not a JSON array (e.g. a string) now returns `"Invalid assistant content: expected list, got <type>"`, matching the improved error parity from Python SDK PR #1058 (commit `d47b180`). ([#454](https://github.com/Flohs/claude-agent-sdk-go/issues/454))
 
 ### Added
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -96,10 +96,17 @@ func parseAssistantMessage(data map[string]any) (*AssistantMessage, error) {
 		}
 	}
 
-	contentRaw, ok := message["content"].([]any)
-	if !ok {
+	rawContent, hasContent := message["content"]
+	if !hasContent || rawContent == nil {
 		return nil, &MessageParseError{
 			SDKError: SDKError{Message: "Missing 'content' field in assistant message"},
+			Data:     data,
+		}
+	}
+	contentRaw, ok := rawContent.([]any)
+	if !ok {
+		return nil, &MessageParseError{
+			SDKError: SDKError{Message: fmt.Sprintf("Invalid assistant content: expected list, got %T", rawContent)},
 			Data:     data,
 		}
 	}


### PR DESCRIPTION
Port of Python SDK PR #1058 (commit `d47b180`, merged 2026-06-26).

`parseAssistantMessage` previously used a single type assertion `message["content"].([]any)`, which returned `false` for both a missing key **and** a present-but-wrong-type value (e.g. a plain string). Both paths returned the same `"Missing 'content' field in assistant message"` error, making it hard to diagnose malformed payloads.

This PR separates the two checks:

1. `message["content"]` absent or `nil` → unchanged error: `"Missing 'content' field in assistant message"`
2. Field present but not `[]any` → new error: `"Invalid assistant content: expected list, got <type>"`

The Go SDK was already safe (no panic), unlike the Python SDK where iterating a string character-by-character caused an uncaught `TypeError`. This change is purely an error-message quality improvement.

Closes #454