### PR TITLE
fix(message_parser): return MessageParseError for non-dict content blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - On Windows, spawning the CLI subprocess no longer flashes a brief console window. `SubprocessTransport.Connect` now sets `cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}` (Windows-only, isolated via build tags) before calling `cmd.Start()`. Port of TypeScript SDK v0.3.193. ([#453](https://github.com/Flohs/claude-agent-sdk-go/issues/453))
 - `parseAssistantMessage` now distinguishes a missing `content` field from a present-but-wrong-type field. A `nil` or absent key returns `"Missing 'content' field in assistant message"` as before; a non-nil value that is not a JSON array (e.g. a string) now returns `"Invalid assistant content: expected list, got <type>"`, matching the improved error parity from Python SDK PR #1058 (commit `d47b180`). ([#454](https://github.com/Flohs/claude-agent-sdk-go/issues/454))
+- `parseContentBlocks` now returns a `*MessageParseError` when any element in the content array is not a JSON object (e.g. a bare string or number), instead of silently dropping the block. Previously a content array like `["unexpected_string"]` would produce an empty content slice with no error, making malformed data invisible to consumers. Port of Python SDK PR anthropics/claude-agent-sdk-python#1058 (commit `d47b180`). ([#459](https://github.com/Flohs/claude-agent-sdk-go/issues/459))
 
 ### Added
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -456,7 +456,11 @@ func parseContentBlocks(raw []any) ([]ContentBlock, error) {
 	for _, item := range raw {
 		blockMap, ok := item.(map[string]any)
 		if !ok {
-			continue
+			return nil, &MessageParseError{
+				SDKError: SDKError{
+					Message: fmt.Sprintf("Invalid content block: expected object, got %T", item),
+				},
+			}
 		}
 		blockType, _ := blockMap["type"].(string)
 		switch blockType {

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -1464,3 +1464,42 @@ func TestParseSystemMessage_ModelFallback(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests for non-dict content block validation — issue #459
+// Port of Python SDK PR anthropics/claude-agent-sdk-python#1058 (commit d47b180).
+// ---------------------------------------------------------------------------
+
+func TestParseMessage_NonDictContentBlock_AssistantReturnsError(t *testing.T) {
+	data := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"content": []any{"unexpected_string"},
+			"model":   "claude-sonnet-4-6",
+		},
+	}
+	_, err := ParseMessage(data)
+	if err == nil {
+		t.Fatal("expected error for non-dict content block in assistant message, got nil")
+	}
+	if _, ok := err.(*MessageParseError); !ok {
+		t.Fatalf("expected *MessageParseError, got %T: %v", err, err)
+	}
+}
+
+func TestParseMessage_NonDictContentBlock_UserReturnsError(t *testing.T) {
+	data := map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"role":    "user",
+			"content": []any{42},
+		},
+	}
+	_, err := ParseMessage(data)
+	if err == nil {
+		t.Fatal("expected error for non-dict content block in user message, got nil")
+	}
+	if _, ok := err.(*MessageParseError); !ok {
+		t.Fatalf("expected *MessageParseError, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #459.

`parseContentBlocks` previously silently dropped any content-array element that was not a `map[string]any` (e.g. a bare string like `"unexpected_string"`) via a bare `continue`. Consumers received a valid-looking message with zero content blocks and no indication that data was lost.

This PR changes `parseContentBlocks` to return `*MessageParseError` for any non-dict element, matching the Python SDK's behaviour after [anthropics/claude-agent-sdk-python#1058](https://github.com/anthropics/claude-agent-sdk-python/pull/1058) (commit [`d47b180`](https://github.com/anthropics/claude-agent-sdk-python/commit/d47b180)).

**Note:** the first half of that Python PR (returning an error when `message.content` is not a JSON array, rather than a string) was already ported in #454. This PR completes the second half.

## Changes

- `message_parser.go`: replace `continue` with a `*MessageParseError` return in `parseContentBlocks` when an element is not a `map[string]any`.
- `message_parser_test.go`: two new tests — `TestParseMessage_NonDictContentBlock_AssistantReturnsError` and `TestParseMessage_NonDictContentBlock_UserReturnsError`.
- `CHANGELOG.md`: entry under `[Unreleased] > Fixed`.

## Upstream reference

- Python SDK commit: [`d47b180`](https://github.com/anthropics/claude-agent-sdk-python/commit/d47b180) — "Fix uncaught TypeError on string or non-dict message content (#1058)"


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4aNfqZ6HnUtm4BBdpLQJE)_