### PR TITLE
docs: document subagent-limiting env vars from TS SDK v0.3.217

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Documented the CLI's two subagent-limiting environment variables, `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (default 1) and `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20), near `Options.Env`. Reviewed TypeScript SDK v0.3.217: aside from these (CLI-behavior-only, no `.d.ts` schema change), the only other changes were a Remote Control bridge fix (`bridge.d.ts`) scoped to the claude.ai browser/companion-app bridge, which this single-subprocess-transport Go SDK doesn't implement, and new desktop-app `Settings` UI preference fields outside the Agent SDK's client/query surface. No functional Go SDK changes required. ([#536](https://github.com/Flohs/claude-agent-sdk-go/issues/536))
+
 ### Fixed
 
 - `examples/session_stores/s3`'s pinned `github.com/aws/aws-sdk-go-v2/service/s3` (`v1.79.5`) had its upstream git tag removed, which broke the module entirely (`go build`/`go mod tidy` failed with `unknown revision service/s3/v1.79.5`) and blocked Dependabot from opening its own security-update PR for a since-patched advisory affecting versions `< 1.97.3`. Bumped directly to `v1.97.3` (pulling in `aws-sdk-go-v2` core `v1.41.5` and other transitive requirements via `go mod tidy`), fixing both the build breakage and the underlying advisory.

--- a/options.go
+++ b/options.go
@@ -426,6 +426,12 @@ type Options struct {
 	//
 	// Note: unlike the TypeScript SDK (where options.env replaces the subprocess
 	// environment), the Go SDK merges Env on top of the inherited environment.
+	//
+	// The CLI also honors two subagent-limiting env vars (set here, not via a
+	// typed Options field, since the TS SDK exposes no corresponding schema
+	// change either): CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH (default 1) caps
+	// subagent nesting depth, and CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS (default
+	// 20) caps concurrently-running subagents.
 	Env map[string]string
 	// InheritEnv controls whether the CLI subprocess inherits the parent process
 	// environment. Defaults to true when nil. When set to false, the subprocess


### PR DESCRIPTION
## Summary

Reviews upstream TypeScript SDK v0.3.217 and documents the one actionable, non-breaking finding: two new CLI environment variables that limit subagent spawning. No typed API surface changed upstream (confirmed by diffing the `0.3.216` → `0.3.217` bundled `.d.ts` files), so this is a documentation-only change.

Closes #536.

## Changes

- `options.go`: doc-comment near `Options.Env` documenting `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` (default 1) and `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (default 20), both already passthrough-able via the existing `Options.Env` map.
- `CHANGELOG.md`: records v0.3.217 as reviewed, with a note on why the other two changes in that release (a Remote Control bridge fix, new desktop `Settings` UI fields) don't apply to this Go SDK.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] New tests added (if applicable) — not applicable, doc-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv7kaE7MM2hT7wqRgnHUi6)_