### PR TITLE
fix(options): validate skill names in Options.Skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `Options.Skills` names are now validated at connect time before being formatted into `Skill(name)` `--allowedTools` rules. The CLI tokenizes `--allowedTools` on commas and spaces outside parentheses with no escape sequences, so a name carrying one of those delimiters couldn't ride through reliably; some other shapes tokenized cleanly but could never match a real skill, silently granting nothing. `NewSubprocessTransport` now rejects, with a `*SDKError`: an `Options.Skills` value that isn't `nil`, `"all"`, or `[]string`; and, per name, empty/whitespace-only names, invalid UTF-8, parentheses/commas/control characters/byte-order marks, a literal `"*"`, a `":*"`/`" *"` wildcard suffix, a leading `"/"`, consecutive backslashes, and a trailing unpaired backslash. Plugin-qualified names, interior spaces, single backslashes, and non-ASCII names are unaffected. **Breaking:** `Skills: []string{"plugin:*"}` and `Skills: []string{"*"}` now return an error instead of silently building a dead rule — use `Skills: "all"` or a `Skill(...)` `AllowedTools` entry instead. Port of Python SDK PR anthropics/claude-agent-sdk-python#1145, mirrored in TypeScript SDK v0.3.221. ([#557](https://github.com/Flohs/claude-agent-sdk-go/issues/557))
+
 ## [3.0.0] - 2026-07-28
 
 ### Breaking

--- a/options.go
+++ b/options.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Model string constants for use with Options.Model.
@@ -77,6 +79,100 @@ func validatePermissionMode(mode PermissionMode) error {
 		"invalid PermissionMode %q: must be one of %s",
 		string(mode), strings.Join(valid, ", "),
 	)}
+}
+
+// validateSkills rejects an Options.Skills value that isn't nil, "all", or
+// []string, and validates every name in a []string. Names are formatted by
+// applySkillsDefaults into "Skill(name)" rules joined into the CLI's
+// --allowedTools argument, which is tokenized on commas and spaces outside
+// parentheses with no escape sequences — a name carrying one of those
+// delimiters cannot be passed through reliably. Names that tokenize cleanly
+// but can never match the listed skill (surrounding whitespace, a leading
+// "/", a wildcard suffix) are rejected too, so a dead rule fails loudly here
+// instead of silently granting nothing. Port of Python SDK PR
+// anthropics/claude-agent-sdk-python#1145, mirrored in TypeScript SDK
+// v0.3.221. ([#557](https://github.com/Flohs/claude-agent-sdk-go/issues/557))
+func validateSkills(skills any) error {
+	if skills == nil {
+		return nil
+	}
+	switch s := skills.(type) {
+	case string:
+		if s == "all" {
+			return nil
+		}
+		return &SDKError{Message: fmt.Sprintf(
+			`Options.Skills must be []string or "all", got %q. Did you mean []string{%q}?`,
+			s, s,
+		)}
+	case []string:
+		for _, name := range s {
+			if err := validateSkillName(name); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return &SDKError{Message: fmt.Sprintf(
+			`Options.Skills must be []string or "all", got %T`, skills,
+		)}
+	}
+}
+
+// validateSkillName rejects a single skill name unsafe for or unable to
+// match through a "Skill(name)" --allowedTools rule. See validateSkills.
+func validateSkillName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return &SDKError{Message: "skill names must be non-empty strings"}
+	}
+	if !utf8.ValidString(name) {
+		return &SDKError{Message: fmt.Sprintf(
+			"invalid skill name %q: not valid UTF-8, which can never match a skill the CLI discovered",
+			name,
+		)}
+	}
+	if strings.TrimSpace(name) != name {
+		return &SDKError{Message: fmt.Sprintf(
+			"invalid skill name %q: leading or trailing whitespace can never match — the Skill tool trims the invoked name",
+			name,
+		)}
+	}
+	for _, r := range name {
+		if r == '(' || r == ')' || r == ',' || r == '\ufeff' || unicode.IsControl(r) {
+			return &SDKError{Message: fmt.Sprintf(
+				"invalid skill name %q: parentheses, commas, control characters, and byte-order marks are not allowed. Names match the skill's directory name, or \"plugin:skill\" for plugin-qualified skills",
+				name,
+			)}
+		}
+	}
+	if name == "*" {
+		return &SDKError{Message: `invalid skill name "*": use Skills: "all" to enable every skill`}
+	}
+	if strings.HasSuffix(name, ":*") || strings.HasSuffix(name, " *") {
+		return &SDKError{Message: fmt.Sprintf(
+			"invalid skill name %q: wildcard-suffix names are not allowed; list each skill by its exact name",
+			name,
+		)}
+	}
+	if strings.HasPrefix(name, "/") {
+		return &SDKError{Message: fmt.Sprintf(
+			`invalid skill name %q: skill names may not start with "/". The Skills option takes the canonical name, not the slash-command form`,
+			name,
+		)}
+	}
+	if strings.Contains(name, `\\`) {
+		return &SDKError{Message: fmt.Sprintf(
+			"invalid skill name %q: consecutive backslashes are not allowed — the per-rule parser collapses them, so the rule would name a different skill",
+			name,
+		)}
+	}
+	if strings.HasSuffix(name, `\`) {
+		return &SDKError{Message: fmt.Sprintf(
+			"invalid skill name %q: names may not end with an unpaired backslash",
+			name,
+		)}
+	}
+	return nil
 }
 
 // SdkBeta represents beta feature flags.
@@ -510,6 +606,10 @@ type Options struct {
 	// the string "all" for every discovered skill, or leave nil to disable.
 	// When set, the SDK automatically injects Skill tool entries into
 	// AllowedTools and defaults SettingSources to [user, project] if unset.
+	// Any other value, and any []string name containing delimiters
+	// (parentheses, commas, control characters), a leading "/", a wildcard
+	// suffix, surrounding whitespace, or invalid UTF-8, is rejected with an
+	// error at connect time.
 	Skills any // []string | "all" | nil
 	// SettingSources specifies which setting sources to load.
 	SettingSources []SettingSource

--- a/options_test.go
+++ b/options_test.go
@@ -266,3 +266,103 @@ func TestValidatePermissionMode_InvalidValue(t *testing.T) {
 		t.Errorf("expected error to be a *SDKError, got %T", err)
 	}
 }
+
+// TestValidateSkills_Accepted verifies that nil, "all", and ordinary
+// []string names (including plugin-qualified names, interior spaces, single
+// backslashes, and non-ASCII) build without error.
+func TestValidateSkills_Accepted(t *testing.T) {
+	accepted := []any{
+		nil,
+		"all",
+		[]string{},
+		[]string{"pdf-tools"},
+		[]string{"plugin:skill"},
+		[]string{"my skill"},
+		[]string{"a\\b"},
+		[]string{"日本語スキル"},
+	}
+	for _, skills := range accepted {
+		if err := validateSkills(skills); err != nil {
+			t.Errorf("validateSkills(%#v) = %v, want nil", skills, err)
+		}
+	}
+}
+
+// TestValidateSkills_RejectedShape verifies that an Options.Skills value
+// other than nil, "all", or []string is rejected instead of silently
+// no-op'd.
+func TestValidateSkills_RejectedShape(t *testing.T) {
+	rejected := []any{"named", 42, []int{1, 2}}
+	for _, skills := range rejected {
+		if err := validateSkills(skills); err == nil {
+			t.Errorf("validateSkills(%#v) = nil, want error", skills)
+		} else if _, ok := err.(*SDKError); !ok {
+			t.Errorf("validateSkills(%#v) error type = %T, want *SDKError", skills, err)
+		}
+	}
+}
+
+// TestValidateSkillName_Rejected verifies every documented rejection case:
+// delimiters that the --allowedTools tokenizer can't carry safely, and
+// shapes that tokenize cleanly but can never match a real skill.
+func TestValidateSkillName_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+	}{
+		{""},
+		{"   "},
+		{" name"},
+		{"name "},
+		{"a(b"},
+		{"a)b"},
+		{"a,b"},
+		{"a\x01b"},
+		{"a\x7fb"},
+		{"a\ufeffb"},
+		{"*"},
+		{"plugin:*"},
+		{"name *"},
+		{"/name"},
+		{"a\\\\b"},
+		{"name\\"},
+	}
+	for _, c := range cases {
+		if err := validateSkillName(c.name); err == nil {
+			t.Errorf("validateSkillName(%q) = nil, want error", c.name)
+		} else if _, ok := err.(*SDKError); !ok {
+			t.Errorf("validateSkillName(%q) error type = %T, want *SDKError", c.name, err)
+		}
+	}
+}
+
+// TestValidateSkillName_Accepted verifies names that must keep working
+// identically: plugin-qualified names, interior spaces, a single backslash,
+// and non-ASCII.
+func TestValidateSkillName_Accepted(t *testing.T) {
+	accepted := []string{
+		"pdf-tools",
+		"plugin:skill",
+		"my skill",
+		"a\\b",
+		"日本語スキル",
+		"name:not-a-wildcard",
+	}
+	for _, name := range accepted {
+		if err := validateSkillName(name); err != nil {
+			t.Errorf("validateSkillName(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+// TestNewSubprocessTransport_RejectsInvalidSkills verifies that an invalid
+// Options.Skills value fails at construction, before any CLI process is
+// spawned.
+func TestNewSubprocessTransport_RejectsInvalidSkills(t *testing.T) {
+	_, err := NewSubprocessTransport(&Options{Skills: []string{"bad,name"}})
+	if err == nil {
+		t.Fatal("expected error for invalid skill name, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad,name") {
+		t.Errorf("error message = %q, want it to contain %q", err.Error(), "bad,name")
+	}
+}

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -155,6 +155,10 @@ func NewSubprocessTransport(opts *Options) (*SubprocessTransport, error) {
 		return nil, err
 	}
 
+	if err := validateSkills(opts.Skills); err != nil {
+		return nil, err
+	}
+
 	t := &SubprocessTransport{
 		options:    opts,
 		cwd:       opts.Cwd,


### PR DESCRIPTION
## Summary

Validates `Options.Skills` at connect time, before its names are formatted into `Skill(name)` `--allowedTools` rules. Port of Python SDK PR [anthropics/claude-agent-sdk-python#1145](https://github.com/anthropics/claude-agent-sdk-python/commit/cbed47d8226e5f677d1f6ffd14269947602d5ae3), mirrored in TypeScript SDK [0.3.221](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#0.3.221).

The CLI tokenizes `--allowedTools` on commas and spaces outside parentheses with no escape sequences, so a skill name carrying one of those delimiters couldn't ride through reliably. Some other shapes tokenized cleanly but could never match a real skill (leading `/`, surrounding whitespace, wildcard suffixes), silently granting nothing instead of failing loudly.

Closes #557

## Changes

- `options.go`: new `validateSkills`/`validateSkillName`, wired into `NewSubprocessTransport` alongside the existing `validatePermissionMode` check, so invalid values fail before the CLI subprocess is spawned.
- Rejects: an `Options.Skills` value that isn't `nil`, `"all"`, or `[]string`; and, per name, empty/whitespace-only names, invalid UTF-8, parentheses/commas/control characters/BOM, a literal `"*"`, a `":*"`/`" *"` wildcard suffix, a leading `"/"`, consecutive backslashes, and a trailing unpaired backslash.
- Unaffected: plugin-qualified names (`plugin:skill`), interior spaces, a single backslash, non-ASCII names.
- `Options.Skills` doc comment updated to note the new validation.
- `CHANGELOG.md` entry, including the breaking-change note: `Skills: []string{"plugin:*"}` / `Skills: []string{"*"}` now error instead of building a dead rule.

**Breaking:** as above — matches the breaking change upstream made in the same port.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests added: `TestValidateSkills_Accepted`, `TestValidateSkills_RejectedShape`, `TestValidateSkillName_Rejected`, `TestValidateSkillName_Accepted`, `TestNewSubprocessTransport_RejectsInvalidSkills` in `options_test.go`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBFxCS7x8vocok7a2JcKBG)_