### PR TITLE
feat(options): add Options.ResumeSessionAt and Options.ResumeDropsTurn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Options.ResumeSessionAt` and `Options.ResumeDropsTurn` fields, bound to the CLI's `--resume-session-at`/`--resume-drops-turn` flags via the existing `appendFlagValue` dash-leading-safe helper. `ResumeSessionAt` truncates a `Resume`d session to a specific chain-entry UUID instead of loading the full transcript; `ResumeDropsTurn` declares the prompt UUID of the turn a truncating resume intends to discard, so the CLI can refuse the resume if the discarded range contains anything the caller hadn't already observed. Print/headless lane only — interactive `--resume` and background-job worker boots ignore both. Port of TypeScript SDK v0.3.212 (`resumeSessionAt`) / v0.3.223 (`resumeDropsTurn`). ([#561](https://github.com/Flohs/claude-agent-sdk-go/issues/561))
+
 ### Fixed
 
 - `materializeResumeSession` (used by `Options.SessionStore` + `Options.Resume`/`ContinueConversation`) now copies the caller's `settings.json` into the resumed subprocess's temp `CLAUDE_CONFIG_DIR`, alongside the existing `.credentials.json`/`.claude.json` copies. Previously, because the resumed subprocess runs under a redirected `CLAUDE_CONFIG_DIR`, the caller's real `settings.json` — and with it `apiKeyHelper`, `env`, `hooks`, and `permissions` — silently stopped applying for a session-store-backed resume, even though it applies for a normal (non-store) resume. Port of TypeScript SDK v0.3.222. ([#559](https://github.com/Flohs/claude-agent-sdk-go/issues/559))

--- a/options.go
+++ b/options.go
@@ -505,6 +505,28 @@ type Options struct {
 	ContinueConversation bool
 	// Resume resumes a specific session by ID.
 	Resume string
+	// ResumeSessionAt truncates a Resume'd session to a specific chain-entry
+	// UUID instead of loading the full transcript — only messages up to and
+	// including this UUID are resumed. Use together with Resume. Accepts any
+	// chain-entry UUID, typically an AssistantMessage's UUID. Print/headless
+	// lane only: interactive `--resume` and background-job worker boots
+	// ignore this option and load the full chain unmodified. Port of
+	// TypeScript SDK v0.3.212. ([#561])
+	//
+	// [#561]: https://github.com/Flohs/claude-agent-sdk-go/issues/561
+	ResumeSessionAt string
+	// ResumeDropsTurn declares, together with ResumeSessionAt, the prompt
+	// UUID of the turn a truncating resume intends to discard. The CLI
+	// validates at fork time that every entry past ResumeSessionAt is
+	// attributable to that turn and refuses the resume — an
+	// error_during_execution result whose message starts with "Resume
+	// rejected by --resume-drops-turn:" — if the discarded range contains
+	// anything else (e.g. a queued user message the caller hadn't yet
+	// observed). The refusal is deterministic: map it to a rewind-recovery
+	// path rather than retrying the same fork request. Print/headless lane
+	// only, same as ResumeSessionAt. Port of TypeScript SDK v0.3.223.
+	// ([#561])
+	ResumeDropsTurn string
 	// SessionID specifies a custom session ID for the conversation.
 	SessionID string
 	// Title sets the session title and skips auto-generation.

--- a/subprocess_transport.go
+++ b/subprocess_transport.go
@@ -727,6 +727,14 @@ func (t *SubprocessTransport) buildCommand() []string {
 		cmd = appendFlagValue(cmd, "resume", opts.Resume)
 	}
 
+	if opts.ResumeSessionAt != "" {
+		cmd = appendFlagValue(cmd, "resume-session-at", opts.ResumeSessionAt)
+	}
+
+	if opts.ResumeDropsTurn != "" {
+		cmd = appendFlagValue(cmd, "resume-drops-turn", opts.ResumeDropsTurn)
+	}
+
 	if opts.SessionID != "" {
 		cmd = appendFlagValue(cmd, "session-id", opts.SessionID)
 	}

--- a/subprocess_transport_test.go
+++ b/subprocess_transport_test.go
@@ -219,6 +219,56 @@ func TestBuildCommand_SessionIDFlagLikeValue(t *testing.T) {
 	assertNotContainsFlag(t, cmd, "--version")
 }
 
+func TestBuildCommand_ResumeSessionAt(t *testing.T) {
+	transport := &SubprocessTransport{
+		cliPath: "claude",
+		options: &Options{
+			Resume:          "session-abc",
+			ResumeSessionAt: "msg-uuid-123",
+		},
+	}
+	cmd := transport.buildCommand()
+	assertContains(t, cmd, "--resume", "session-abc")
+	assertContains(t, cmd, "--resume-session-at", "msg-uuid-123")
+}
+
+func TestBuildCommand_ResumeSessionAtFlagLikeValue(t *testing.T) {
+	transport := &SubprocessTransport{
+		cliPath: "claude",
+		options: &Options{
+			ResumeSessionAt: "--version",
+		},
+	}
+	cmd := transport.buildCommand()
+	assertContainsFlag(t, cmd, "--resume-session-at=--version")
+	assertNotContainsFlag(t, cmd, "--version")
+}
+
+func TestBuildCommand_ResumeDropsTurn(t *testing.T) {
+	transport := &SubprocessTransport{
+		cliPath: "claude",
+		options: &Options{
+			Resume:          "session-abc",
+			ResumeSessionAt: "msg-uuid-123",
+			ResumeDropsTurn: "prompt-uuid-456",
+		},
+	}
+	cmd := transport.buildCommand()
+	assertContains(t, cmd, "--resume-drops-turn", "prompt-uuid-456")
+}
+
+func TestBuildCommand_ResumeDropsTurnFlagLikeValue(t *testing.T) {
+	transport := &SubprocessTransport{
+		cliPath: "claude",
+		options: &Options{
+			ResumeDropsTurn: "--version",
+		},
+	}
+	cmd := transport.buildCommand()
+	assertContainsFlag(t, cmd, "--resume-drops-turn=--version")
+	assertNotContainsFlag(t, cmd, "--version")
+}
+
 func TestConnectEnv_IncludePartialMessages(t *testing.T) {
 	t.Run("does not set CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING even when true", func(t *testing.T) {
 		env := buildTestEnv(&Options{IncludePartialMessages: true})


### PR DESCRIPTION
## Summary

Fixes #561. Ports the TypeScript SDK's `resumeSessionAt`/`resumeDropsTurn` `ClaudeAgentOptions` fields, which were entirely missing from this SDK's `Options` struct.

- `Options.ResumeSessionAt` truncates a `Resume`d session to a specific chain-entry UUID instead of loading the full transcript. Port of TypeScript SDK v0.3.212.
- `Options.ResumeDropsTurn` declares, together with `ResumeSessionAt`, the prompt UUID of the turn a truncating resume intends to discard; the CLI refuses the resume if the discarded range contains anything else. Port of TypeScript SDK v0.3.223.

Both bind to their CLI flags (`--resume-session-at`/`--resume-drops-turn`) via the existing dash-leading-safe `appendFlagValue` helper, the same pattern already used for `--resume`/`--session-id`.

Not present in the Python SDK (TS-only wire option), consistent with how this repo has handled other TS-only fields (e.g. #494, #503, #509, #511, #517, #519, #530).

## Changes

- `Options.ResumeSessionAt string` and `Options.ResumeDropsTurn string` fields in `options.go`, with doc comments carrying the caller guidance from the TS `.d.ts` (use with `Resume`, deterministic refusal semantics, print/headless-lane-only).
- `buildCommand` in `subprocess_transport.go` wires both to `--resume-session-at`/`--resume-drops-turn` via `appendFlagValue`.
- `CHANGELOG.md` entry under `[Unreleased] / Added`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New tests: `TestBuildCommand_ResumeSessionAt`, `TestBuildCommand_ResumeSessionAtFlagLikeValue`, `TestBuildCommand_ResumeDropsTurn`, `TestBuildCommand_ResumeDropsTurnFlagLikeValue` (mirroring the existing `TestBuildCommand_ResumeFlagLikeValue`/`TestBuildCommand_SessionIDFlagLikeValue` pattern).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTeuASXVHTAuRMZTcMVbhm)_