### PR TITLE
feat(messages): add PermissionDeniedMessage for permission_denied subtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `Options.ResumeSessionAt` and `Options.ResumeDropsTurn` fields, bound to the CLI's `--resume-session-at`/`--resume-drops-turn` flags via the existing `appendFlagValue` dash-leading-safe helper. `ResumeSessionAt` truncates a `Resume`d session to a specific chain-entry UUID instead of loading the full transcript; `ResumeDropsTurn` declares the prompt UUID of the turn a truncating resume intends to discard, so the CLI can refuse the resume if the discarded range contains anything the caller hadn't already observed. Print/headless lane only — interactive `--resume` and background-job worker boots ignore both. Port of TypeScript SDK v0.3.212 (`resumeSessionAt`) / v0.3.223 (`resumeDropsTurn`). ([#561](https://github.com/Flohs/claude-agent-sdk-go/issues/561))
+- `PermissionDeniedMessage` typed struct for the `system/permission_denied` subtype (`ToolName`, `ToolInput`, `ToolUseID`, `Reason`), emitted when bare headless mode (`-p` / SDK `query()` without `CanUseTool`) auto-denies a tool call. `ParseMessage` now returns `*PermissionDeniedMessage` for this subtype instead of a generic `*SystemMessage`. Distinct from the existing `PermissionDeniedAdvisoryMessage` (`permission_denied_advisory` subtype), which only carries `ToolName`/`DenialReason`. Port of TypeScript SDK v0.3.223. ([#562](https://github.com/Flohs/claude-agent-sdk-go/issues/562))
 
 ### Fixed
 

--- a/message_parser.go
+++ b/message_parser.go
@@ -378,6 +378,15 @@ func parseSystemMessage(data map[string]any) (Message, error) {
 			DenialReason:  PermissionDeniedAdvisoryReason(stringField(data, "denial_reason")),
 		}, nil
 
+	case "permission_denied":
+		return &PermissionDeniedMessage{
+			SystemMessage: base,
+			ToolName:      stringField(data, "tool_name"),
+			ToolInput:     data["tool_input"],
+			ToolUseID:     stringField(data, "tool_use_id"),
+			Reason:        stringField(data, "reason"),
+		}, nil
+
 	default:
 		return &base, nil
 	}

--- a/message_parser_test.go
+++ b/message_parser_test.go
@@ -1719,6 +1719,68 @@ func TestParsePermissionDeniedAdvisoryMessage_Minimal(t *testing.T) {
 	}
 }
 
+func TestParsePermissionDeniedMessage(t *testing.T) {
+	data := map[string]any{
+		"type":        "system",
+		"subtype":     "permission_denied",
+		"tool_name":   "Bash",
+		"tool_input":  map[string]any{"command": "rm -rf /"},
+		"tool_use_id": "toolu_123",
+		"reason":      "auto-denied in bare headless mode",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := msg.(*PermissionDeniedMessage)
+	if !ok {
+		t.Fatalf("expected *PermissionDeniedMessage, got %T", msg)
+	}
+	if m.ToolName != "Bash" {
+		t.Errorf("ToolName = %q, want %q", m.ToolName, "Bash")
+	}
+	if m.ToolUseID != "toolu_123" {
+		t.Errorf("ToolUseID = %q, want %q", m.ToolUseID, "toolu_123")
+	}
+	if m.Reason != "auto-denied in bare headless mode" {
+		t.Errorf("Reason = %q, want %q", m.Reason, "auto-denied in bare headless mode")
+	}
+	toolInput, ok := m.ToolInput.(map[string]any)
+	if !ok {
+		t.Fatalf("expected ToolInput to be map[string]any, got %T", m.ToolInput)
+	}
+	if toolInput["command"] != "rm -rf /" {
+		t.Errorf("ToolInput[command] = %v, want %q", toolInput["command"], "rm -rf /")
+	}
+}
+
+func TestParsePermissionDeniedMessage_Minimal(t *testing.T) {
+	data := map[string]any{
+		"type":    "system",
+		"subtype": "permission_denied",
+	}
+	msg, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := msg.(*PermissionDeniedMessage)
+	if !ok {
+		t.Fatalf("expected *PermissionDeniedMessage, got %T", msg)
+	}
+	if m.ToolName != "" {
+		t.Errorf("ToolName should be empty, got %q", m.ToolName)
+	}
+	if m.ToolInput != nil {
+		t.Errorf("ToolInput should be nil, got %v", m.ToolInput)
+	}
+	if m.ToolUseID != "" {
+		t.Errorf("ToolUseID should be empty, got %q", m.ToolUseID)
+	}
+	if m.Reason != "" {
+		t.Errorf("Reason should be empty, got %q", m.Reason)
+	}
+}
+
 func TestParseMessage_MemoryRecall(t *testing.T) {
 	data := map[string]any{
 		"type":    "system",

--- a/types.go
+++ b/types.go
@@ -983,6 +983,26 @@ type PermissionDeniedAdvisoryMessage struct {
 	DenialReason PermissionDeniedAdvisoryReason `json:"denial_reason,omitempty"`
 }
 
+// PermissionDeniedMessage is emitted for the system/permission_denied subtype:
+// bare headless (`-p` / SDK query() without CanUseTool) auto-denying a tool
+// call. Distinct from PermissionDeniedAdvisoryMessage (permission_denied_advisory),
+// which only carries ToolName/DenialReason; this subtype carries the full
+// denied-call details, matching PermissionDeniedHookInput's shape. Port of
+// TypeScript SDK v0.3.223. ([#562])
+//
+// [#562]: https://github.com/Flohs/claude-agent-sdk-go/issues/562
+type PermissionDeniedMessage struct {
+	SystemMessage
+	// ToolName is the name of the tool that was denied.
+	ToolName string `json:"tool_name,omitempty"`
+	// ToolInput is the input the tool call was made with.
+	ToolInput any `json:"tool_input,omitempty"`
+	// ToolUseID is the tool-use ID of the denied call.
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	// Reason is a human-readable explanation for the denial.
+	Reason string `json:"reason,omitempty"`
+}
+
 // HookDecision represents a hook's permission decision value.
 type HookDecision string
 


### PR DESCRIPTION
## Summary

Fixes #562. Ports the TypeScript SDK's `SDKPermissionDeniedMessage` (bundled `sdk.d.ts`), a new `system/permission_denied` subtype: "Bare headless (`-p` / SDK `query()` without `canUseTool`) now emits `system/permission_denied` stream events when a tool call is auto-denied" (TS SDK v0.3.223 changelog).

This is distinct from the existing `permission_denied_advisory` subtype (`PermissionDeniedAdvisoryMessage`), which only carries `tool_name`/`denial_reason`. The new bare `permission_denied` subtype carries the full denied-call details (`tool_name`, `tool_input`, `tool_use_id`, `reason`), matching the shape already used by `PermissionDeniedHookInput`.

Previously this subtype fell through `parseSystemMessage`'s `default` case, producing a generic untyped `*SystemMessage` and silently dropping `tool_input`/`tool_use_id`/`reason` into the opaque `Data` map.

Not present in the Python SDK (TS-only wire type), consistent with how this repo has handled other TS-only fields (e.g. #494, #503, #509, #511, #517, #519, #530).

## Changes

- New `PermissionDeniedMessage` struct in `types.go` (embeds `SystemMessage`; `ToolName`, `ToolInput`, `ToolUseID`, `Reason`).
- New `case "permission_denied":` in `parseSystemMessage` (`message_parser.go`).
- `CHANGELOG.md` entry under `[Unreleased] / Added`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New tests: `TestParsePermissionDeniedMessage`, `TestParsePermissionDeniedMessage_Minimal`, mirroring the existing `TestParsePermissionDeniedAdvisoryMessage_*` pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTeuASXVHTAuRMZTcMVbhm)_