### PR TITLE
feat(types): add BashToolOutput.BackgroundEndsWithFinalResponse (TS SDK v0.3.227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `BashToolOutput.BackgroundEndsWithFinalResponse *bool` field, set when a backgrounded command is owned by a synchronous subagent and is therefore terminated when that agent gives its final response; nil when the command survives the call that started it (main loop, async subagents). Port of TypeScript SDK v0.3.227. ([#576](https://github.com/Flohs/claude-agent-sdk-go/issues/576))
+
 ## [3.1.0] - 2026-08-10
 
 ### Changed

--- a/types.go
+++ b/types.go
@@ -577,12 +577,17 @@ type SkillToolOutput struct {
 // BashToolOutput is the result returned by the Bash tool.
 // Accessible from [PostToolUseHookInput].ToolResponse when ToolName is "Bash"
 // (decode the map[string]any with json.Marshal/Unmarshal, as with [NotebookEditResult]).
-// Port of TypeScript SDK v0.3.210.
+// Port of TypeScript SDK v0.3.210 and v0.3.227.
 type BashToolOutput struct {
 	// TimedOutAfterMs is set when the command was auto-backgrounded after
 	// exceeding its timeout, giving the elapsed time in milliseconds at the
 	// point of backgrounding. Nil when the command completed normally.
 	TimedOutAfterMs *int `json:"timedOutAfterMs,omitempty"`
+	// BackgroundEndsWithFinalResponse is true when this backgrounded command
+	// is owned by a synchronous subagent and is therefore terminated when
+	// that agent gives its final response. Nil when the command survives the
+	// call that started it (main loop, async subagents).
+	BackgroundEndsWithFinalResponse *bool `json:"backgroundEndsWithFinalResponse,omitempty"`
 }
 
 // TaskCreateInput is the input schema for the TaskCreate tool.


### PR DESCRIPTION
## Summary
- Ports the new `backgroundEndsWithFinalResponse` field from the TypeScript SDK's bundled `sdk-tools.d.ts` `BashOutput` type (v0.3.226 → v0.3.227) onto our `BashToolOutput` struct, alongside the already-ported `TimedOutAfterMs` field.
- `*bool`, `omitempty` — true when a backgrounded command is owned by a synchronous subagent and is therefore terminated when that agent gives its final response; nil when the command survives (main loop, async subagents).
- Updated `CHANGELOG.md` under `[Unreleased]`.

Closes #576

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WWWbX9cjsTJ6kvn4HNHz4M)_