### PR TITLE
feat(types): add ProposeGoalInput/ProposeGoalOutput (TS SDK v0.3.227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `BashToolOutput.BackgroundEndsWithFinalResponse *bool` field, set when a backgrounded command is owned by a synchronous subagent and is therefore terminated when that agent gives its final response; nil when the command survives the call that started it (main loop, async subagents). Port of TypeScript SDK v0.3.227. ([#576](https://github.com/Flohs/claude-agent-sdk-go/issues/576))
+- `ProposeGoalInput` (`Condition string`, `AskUser bool`) and `ProposeGoalOutput` (`Condition string`, `AskUser bool`) typed structs for the `ProposeGoal` tool, accessible from `PreToolUseHookInput.ToolInput`/`PostToolUseHookInput.ToolResponse` when `ToolName` is `"ProposeGoal"`. Same shape of feature as the existing `ProposeSkillsInput`/`ProposeSkillsOutput`. Port of TypeScript SDK v0.3.227. ([#577](https://github.com/Flohs/claude-agent-sdk-go/issues/577))
 
 ## [3.1.0] - 2026-08-10
 

--- a/types.go
+++ b/types.go
@@ -558,6 +558,35 @@ type ProposeSkillsOutput struct {
 	ProposalCount int `json:"proposalCount"`
 }
 
+// ProposeGoalInput is the typed input for the ProposeGoal tool. Accessible
+// from [PreToolUseHookInput].ToolInput when ToolName is "ProposeGoal". Port of
+// TypeScript SDK v0.3.227.
+type ProposeGoalInput struct {
+	// Condition is the completion condition to propose, written so a
+	// separate evaluator can verify it from the conversation (e.g. "all
+	// tests in test/auth pass (bun test exits 0)"). At most 500 characters.
+	Condition string `json:"condition"`
+	// AskUser controls whether the user is asked for approval before the
+	// goal is set. Upstream defaults this to true (an approval dialog is
+	// shown) when omitted; false sets the goal directly, with a visible
+	// notice in the transcript, and is only used when the user's own words
+	// in the conversation stated the outcome directly.
+	AskUser bool `json:"ask_user,omitempty"`
+}
+
+// ProposeGoalOutput is the result returned by the ProposeGoal tool.
+// Accessible from [PostToolUseHookInput].ToolResponse when ToolName is
+// "ProposeGoal" (decode the map[string]any with json.Marshal/Unmarshal, as
+// with [NotebookEditResult]). Port of TypeScript SDK v0.3.227.
+type ProposeGoalOutput struct {
+	// Condition is the condition shown to the user for approval, or set
+	// directly when AskUser was false.
+	Condition string `json:"condition"`
+	// AskUser is true when the user was asked for approval, false when the
+	// goal was set directly.
+	AskUser bool `json:"askUser"`
+}
+
 // SkillToolOutput is the result returned by the Skill tool.
 // Accessible from [PostToolUseHookInput].ToolResponse when ToolName is "Skill"
 // (decode the map[string]any with json.Marshal/Unmarshal, as with [NotebookEditResult]).


### PR DESCRIPTION
## Summary
- Adds `ProposeGoalInput` (`Condition string`, `AskUser bool`) and `ProposeGoalOutput` (`Condition string`, `AskUser bool`) typed structs for the new `ProposeGoal` tool introduced in the TypeScript SDK's bundled `sdk-tools.d.ts` (v0.3.226 → v0.3.227).
- Same shape of feature as the already-ported `ProposeSkillsInput`/`ProposeSkillsOutput` (a harness tool proposing something for user approval); modeled with the same doc-comment style.
- Updated `CHANGELOG.md` under `[Unreleased]`.

Closes #577

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WWWbX9cjsTJ6kvn4HNHz4M)_