### PR TITLE
feat(types): add MessageOriginKindUnclassified constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `MessageOriginKindUnclassified` (`"unclassified"`) constant for `MessageOrigin.Kind`, completing the `MessageOriginKind` enum against the Python SDK's `MessageOriginKind` literal union (8 of 9 kinds already had named Go constants; `unclassified` was the missing one). `MessageOrigin.Kind` is a plain `string` field, so this was a discoverability gap, not a parse bug — an unrecognized value already round-tripped through JSON correctly. Port of Python SDK commit [d48fa33](https://github.com/anthropics/claude-agent-sdk-python/commit/d48fa33) (anthropics/claude-agent-sdk-python#1199). ([#583](https://github.com/Flohs/claude-agent-sdk-go/issues/583))
 - `BashToolOutput.BackgroundEndsWithFinalResponse *bool` field, set when a backgrounded command is owned by a synchronous subagent and is therefore terminated when that agent gives its final response; nil when the command survives the call that started it (main loop, async subagents). Port of TypeScript SDK v0.3.227. ([#576](https://github.com/Flohs/claude-agent-sdk-go/issues/576))
 - `ProposeGoalInput` (`Condition string`, `AskUser bool`) and `ProposeGoalOutput` (`Condition string`, `AskUser bool`) typed structs for the `ProposeGoal` tool, accessible from `PreToolUseHookInput.ToolInput`/`PostToolUseHookInput.ToolResponse` when `ToolName` is `"ProposeGoal"`. Same shape of feature as the existing `ProposeSkillsInput`/`ProposeSkillsOutput`. Port of TypeScript SDK v0.3.227. ([#577](https://github.com/Flohs/claude-agent-sdk-go/issues/577))
 

--- a/types.go
+++ b/types.go
@@ -1084,6 +1084,9 @@ const (
 	MessageOriginKindTaskNotification MessageOriginKind = "task-notification"
 	// MessageOriginKindCoordinator is a message sent by the coordinator.
 	MessageOriginKindCoordinator MessageOriginKind = "coordinator"
+	// MessageOriginKindUnclassified is a message whose origin the CLI could
+	// not classify into one of the other kinds.
+	MessageOriginKindUnclassified MessageOriginKind = "unclassified"
 	// MessageOriginKindObserver is a message sent by an observer agent.
 	// From and SenderTaskID are populated.
 	MessageOriginKindObserver MessageOriginKind = "observer"


### PR DESCRIPTION
## Summary
- Adds the missing `MessageOriginKindUnclassified` (`"unclassified"`) constant to `MessageOriginKind`, completing parity with the Python SDK's 9-value `MessageOriginKind` literal union (8 of 9 already had named Go constants).
- Documentation/discoverability fix only — `MessageOrigin.Kind` is a plain `string` field, so unrecognized values already round-tripped through JSON correctly.

## Source
Port of Python SDK commit [d48fa33](https://github.com/anthropics/claude-agent-sdk-python/commit/d48fa33) (anthropics/claude-agent-sdk-python#1199, "Surface message origin on UserMessage and ResultMessage").

Closes #583

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] CHANGELOG.md entry added under Unreleased

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBGu87JATDAscbr1yWtoSJ)_